### PR TITLE
🔀 :: 19 - 로그아웃 기능을 구현하였습니다.

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/common/service/SecurityService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/common/service/SecurityService.kt
@@ -1,0 +1,7 @@
+package team.msg.sms.common.service
+
+import java.util.*
+
+interface SecurityService {
+    fun getCurrentUserId(): UUID
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/common/service/impl/SecurityServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/common/service/impl/SecurityServiceImpl.kt
@@ -1,0 +1,14 @@
+package team.msg.sms.common.service.impl
+
+import team.msg.sms.common.annotation.Service
+import team.msg.sms.common.service.SecurityService
+import team.msg.sms.common.spi.SecurityPort
+import java.util.*
+
+@Service
+class SecurityServiceImpl(
+    private val securityPort: SecurityPort
+) : SecurityService {
+    override fun getCurrentUserId(): UUID =
+        securityPort.getCurrentUserId()
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/common/spi/SecurityPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/common/spi/SecurityPort.kt
@@ -1,0 +1,7 @@
+package team.msg.sms.common.spi
+
+import java.util.UUID
+
+interface SecurityPort {
+    fun getCurrentUserId(): UUID
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/auth/service/AuthService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/auth/service/AuthService.kt
@@ -1,0 +1,10 @@
+package team.msg.sms.domain.auth.service
+
+import team.msg.sms.common.annotation.Service
+
+@Service
+class AuthService(
+    commandAuthService: CommandAuthService,
+    getAuthService: GetAuthService
+) : CommandAuthService by commandAuthService,
+    GetAuthService by getAuthService

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/auth/service/CommandAuthService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/auth/service/CommandAuthService.kt
@@ -1,0 +1,7 @@
+package team.msg.sms.domain.auth.service
+
+import team.msg.sms.domain.auth.model.RefreshToken
+
+interface CommandAuthService {
+    fun deleteRefreshToken(refreshToken: RefreshToken)
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/auth/service/GetAuthService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/auth/service/GetAuthService.kt
@@ -1,0 +1,7 @@
+package team.msg.sms.domain.auth.service
+
+import team.msg.sms.domain.auth.model.RefreshToken
+
+interface GetAuthService {
+    fun getRefreshTokenByToken(token: String): RefreshToken
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/auth/service/impl/CommandAuthServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/auth/service/impl/CommandAuthServiceImpl.kt
@@ -1,0 +1,14 @@
+package team.msg.sms.domain.auth.service.impl
+
+import team.msg.sms.common.annotation.Service
+import team.msg.sms.domain.auth.model.RefreshToken
+import team.msg.sms.domain.auth.service.CommandAuthService
+import team.msg.sms.domain.auth.spi.CommandRefreshTokenPort
+
+@Service
+class CommandAuthServiceImpl(
+    private val commandRefreshTokenPort: CommandRefreshTokenPort
+) : CommandAuthService {
+    override fun deleteRefreshToken(refreshToken: RefreshToken) =
+        commandRefreshTokenPort.deleteRefreshToken(refreshToken)
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/auth/service/impl/GetAuthServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/auth/service/impl/GetAuthServiceImpl.kt
@@ -1,0 +1,16 @@
+package team.msg.sms.domain.auth.service.impl
+
+import team.msg.sms.common.annotation.Service
+import team.msg.sms.domain.auth.exception.RefreshNotFoundException
+import team.msg.sms.domain.auth.model.RefreshToken
+import team.msg.sms.domain.auth.service.GetAuthService
+import team.msg.sms.domain.auth.spi.RefreshTokenPort
+
+@Service
+class GetAuthServiceImpl(
+    private val refreshTokenPort: RefreshTokenPort
+) : GetAuthService {
+    override fun getRefreshTokenByToken(token: String): RefreshToken =
+        refreshTokenPort.queryRefreshTokenByToken(token) ?: throw RefreshNotFoundException
+
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/auth/spi/CommandRefreshTokenPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/auth/spi/CommandRefreshTokenPort.kt
@@ -4,4 +4,5 @@ import team.msg.sms.domain.auth.model.RefreshToken
 
 interface CommandRefreshTokenPort {
     fun saveRefreshToken(refreshToken: RefreshToken): RefreshToken
+    fun deleteRefreshToken(refreshToken: RefreshToken)
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/auth/usecase/LogoutUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/auth/usecase/LogoutUseCase.kt
@@ -10,9 +10,9 @@ class LogoutUseCase(
     private val securityService: SecurityService,
     private val authService: AuthService
 ) {
-    fun execute(header: String) {
+    fun execute(refreshToken: String) {
         val userId = securityService.getCurrentUserId()
-        val token = authService.getRefreshTokenByToken(header)
+        val token = authService.getRefreshTokenByToken(refreshToken)
         if (token.userId == userId) authService.deleteRefreshToken(token) else throw UserNotFoundException
     }
 

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/auth/usecase/LogoutUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/auth/usecase/LogoutUseCase.kt
@@ -1,0 +1,19 @@
+package team.msg.sms.domain.auth.usecase
+
+import team.msg.sms.common.annotation.UseCase
+import team.msg.sms.common.service.SecurityService
+import team.msg.sms.domain.auth.service.AuthService
+import team.msg.sms.domain.user.exception.UserNotFoundException
+
+@UseCase
+class LogoutUseCase(
+    private val securityService: SecurityService,
+    private val authService: AuthService
+) {
+    fun execute(header: String) {
+        val userId = securityService.getCurrentUserId()
+        val token = authService.getRefreshTokenByToken(header)
+        if (token.userId == userId) authService.deleteRefreshToken(token) else throw UserNotFoundException
+    }
+
+}

--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityAdapter.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityAdapter.kt
@@ -1,0 +1,13 @@
+package team.msg.sms.global.security
+
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import team.msg.sms.common.spi.SecurityPort
+import java.util.*
+
+@Component
+class SecurityAdapter(
+) : SecurityPort {
+    override fun getCurrentUserId(): UUID =
+        UUID.fromString(SecurityContextHolder.getContext().authentication.name)
+}

--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
@@ -35,6 +35,7 @@ class SecurityConfig(
             // auth
             .antMatchers(HttpMethod.POST, "/auth").permitAll()
             .antMatchers(HttpMethod.PATCH, "/auth").permitAll()
+            .antMatchers(HttpMethod.DELETE, "/auth").authenticated()
 
             .anyRequest().authenticated()
 

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/auth/RefreshTokenPersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/auth/RefreshTokenPersistenceAdapter.kt
@@ -16,6 +16,10 @@ class RefreshTokenPersistenceAdapter(
             .save(refreshToken.toEntity())
             .toDomain()
 
+    override fun deleteRefreshToken(refreshToken: RefreshToken) {
+        refreshTokenRepository.delete(refreshToken.toEntity())
+    }
+
     override fun queryRefreshTokenByToken(token: String): RefreshToken? =
         refreshTokenRepository.findByToken(token)?.toDomain()
 }

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/auth/AuthWebAdapter.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/auth/AuthWebAdapter.kt
@@ -1,14 +1,11 @@
 package team.msg.sms.domain.auth
 
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PatchMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import team.msg.sms.domain.auth.dto.SignInRequest
+import team.msg.sms.domain.auth.dto.response.ReIssueTokenResponse
 import team.msg.sms.domain.auth.dto.response.SignInResponse
+import team.msg.sms.domain.auth.usecase.LogoutUseCase
 import team.msg.sms.domain.auth.usecase.ReIssueTokenUseCase
 import team.msg.sms.domain.auth.usecase.SignInUseCase
 import javax.validation.Valid
@@ -17,7 +14,8 @@ import javax.validation.Valid
 @RequestMapping("/auth")
 class AuthWebAdapter(
     private val signInUseCase: SignInUseCase,
-    private val reIssueTokenUseCase: ReIssueTokenUseCase
+    private val reIssueTokenUseCase: ReIssueTokenUseCase,
+    private val logoutUseCase: LogoutUseCase
 ) {
 
     @PostMapping
@@ -26,8 +24,12 @@ class AuthWebAdapter(
             .let { ResponseEntity.ok(it) }
 
     @PatchMapping
-    fun reIssueToken(@Valid @RequestHeader("Refresh-Token") header: String) =
+    fun reIssueToken(@Valid @RequestHeader("Refresh-Token") header: String): ResponseEntity<ReIssueTokenResponse> =
         reIssueTokenUseCase.execute(header)
             .let { ResponseEntity.ok(it) }
 
+    @DeleteMapping
+    fun logout(@Valid @RequestHeader("Refresh-Token") header: String): ResponseEntity<Void> =
+        logoutUseCase.execute(header)
+            .let { ResponseEntity.ok().build() }
 }

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/auth/AuthWebAdapter.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/auth/AuthWebAdapter.kt
@@ -29,7 +29,7 @@ class AuthWebAdapter(
             .let { ResponseEntity.ok(it) }
 
     @DeleteMapping
-    fun logout(@Valid @RequestHeader("Refresh-Token") header: String): ResponseEntity<Void> =
-        logoutUseCase.execute(header)
+    fun logout(@Valid @RequestHeader("Refresh-Token") refreshToken: String): ResponseEntity<Void> =
+        logoutUseCase.execute(refreshToken)
             .let { ResponseEntity.ok().build() }
 }


### PR DESCRIPTION
## 💡 개요

## 📃 작업내용
AuthApdater의 매핑추가 및 Security 연결, 
리프레시토큰을 삭제하는 함수 생성, 
AuthService에서 Port 하기위해 AuthService를 생성, 
현재 로그인한 유저의 id값을 가져오는 기능 구현
## 🔀 변경사항

## 🙋‍♂️ 질문사항
음... deleteById는 동작하지 않아 delete로 처리하였는데 이 방법은 해결법을 계속해서 찾아봐야 할거 같습니다.
## 🍴 사용방법
서버주소/auth 주소에 Delete 메소드로 header에 Authorization 부분엔 Bearer를 붙인 AccessToken을 Refresh-Token 부분엔 Bearer를 붙이지 않은 RefreshToken을 보내게 되면 
성공시 200
실패시 
리프레시 토큰이 없을 경우 - 404 리프레시 토큰을 찾지 못함
요청보낸 유저 아이디값과 저장된 리프레시토큰의 유저의 아이디값이 다를 경우 - 404 유저를 찾지 못함
의 에러가 발생합니다
## 🎸 기타
