### PR TITLE
🔀 :: 27 - 이미지 업로드 기능 구현

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/common/util/FileUtil.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/common/util/FileUtil.kt
@@ -9,7 +9,7 @@ object FileUtil {
 
     fun String.isHWPCorrectExtension() =
         when (this.lowercase()) {
-            "hwp" -> true
+            "hwp", "hwpx" -> true
             else -> false
         }
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/file/usecase/UploadFileUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/file/usecase/UploadFileUseCase.kt
@@ -11,7 +11,7 @@ class UploadFileUseCase(
     private val uploadFilePort: UploadFilePort
 ) {
     fun execute(file: File): String {
-        if (file.extension.isHWPCorrectExtension()) {
+        if (!file.extension.isHWPCorrectExtension()) {
             file.delete()
             throw FileInvalidExtensionException
         }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/file/usecase/UploadImageUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/file/usecase/UploadImageUseCase.kt
@@ -11,7 +11,7 @@ class UploadImageUseCase(
     private val uploadFilePort: UploadFilePort
 ) {
     fun execute(file: File): String {
-        if (file.extension.isImageCorrectExtension()) {
+        if (!file.extension.isImageCorrectExtension()) {
             file.delete()
             throw FileInvalidExtensionException
         }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/file/usecase/UploadImageUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/file/usecase/UploadImageUseCase.kt
@@ -1,0 +1,20 @@
+package team.msg.sms.domain.file.usecase
+
+import team.msg.sms.common.annotation.Service
+import team.msg.sms.common.util.FileUtil.isImageCorrectExtension
+import team.msg.sms.domain.file.exception.FileInvalidExtensionException
+import team.msg.sms.domain.file.spi.UploadFilePort
+import java.io.File
+
+@Service
+class UploadImageUseCase(
+    private val uploadFilePort: UploadFilePort
+) {
+    fun execute(file: File): String {
+        if (file.extension.isImageCorrectExtension()) {
+            file.delete()
+            throw FileInvalidExtensionException
+        }
+        return uploadFilePort.upload(file)
+    }
+}

--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
@@ -40,6 +40,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.POST, "/student").authenticated()
 
             .antMatchers(HttpMethod.POST, "/file").authenticated()
+            .antMatchers(HttpMethod.POST, "/file/image").authenticated()
 
             .anyRequest().authenticated()
 

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/file/FileWebAdapter.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/file/FileWebAdapter.kt
@@ -7,16 +7,25 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 import team.msg.sms.common.extension.toFile
 import team.msg.sms.domain.file.dto.res.UploadFileResponse
+import team.msg.sms.domain.file.dto.res.UploadImageResponse
 import team.msg.sms.domain.file.usecase.UploadFileUseCase
+import team.msg.sms.domain.file.usecase.UploadImageUseCase
 
 @RestController
 @RequestMapping("/file")
 class FileWebAdapter(
-    private val uploadFileUseCase: UploadFileUseCase
+    private val uploadFileUseCase: UploadFileUseCase,
+    private val uploadImageUseCase: UploadImageUseCase
 ) {
     @PostMapping
     fun uploadFile(@RequestPart(name = "file") file: MultipartFile?): UploadFileResponse {
         val result = uploadFileUseCase.execute(file = file!!.toFile())
         return UploadFileResponse(result)
+    }
+
+    @PostMapping("/image")
+    fun uploadImage(@RequestPart(name = "file") file: MultipartFile?): UploadImageResponse {
+        val result = uploadImageUseCase.execute(file = file!!.toFile())
+        return UploadImageResponse(result)
     }
 }

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/file/dto/res/UploadImageResponse.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/file/dto/res/UploadImageResponse.kt
@@ -1,0 +1,5 @@
+package team.msg.sms.domain.file.dto.res
+
+data class UploadImageResponse(
+    val fileUrl: String
+)


### PR DESCRIPTION
## 💡 개요

## 📃 작업내용
이미지 업로드 기능을 구현하였습니다.
jpg, jpeg, png, heic 파일이 아니면 에러가 나도록 했습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
