### PR TITLE
PropertiesScan 범위를 BasePackageClasses 로 변경

### DIFF
--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/config/PropertiesScanConfig.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/config/PropertiesScanConfig.kt
@@ -2,8 +2,16 @@ package team.msg.sms.global.config
 
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.context.annotation.Configuration
+import team.msg.sms.global.security.SecurityProperties
+import team.msg.sms.thirdparty.aws.AwsProperties
+import team.msg.sms.thirdparty.gauth.GAuthProperties
 
 @Configuration
-@ConfigurationPropertiesScan(basePackages = ["team.msg.sms"])
+@ConfigurationPropertiesScan(
+    basePackageClasses = [
+        SecurityProperties::class,
+        AwsProperties::class,
+        GAuthProperties::class
+    ])
 class PropertiesScanConfig {
 }


### PR DESCRIPTION
## 💡 개요
PropertiesScan 범위를 BasePackageClasses 로 변경
## 📃 작업내용
BasePackageClasses 에다가 ConfigurationProperties 어노테이션 붙은 패키지만 검사하게 범위를 좁힘
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
