### PR TITLE
🔀 :: 63 - 로그인과 로그아웃 쿠키 추가

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/auth/dto/response/SignInResponse.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/auth/dto/response/SignInResponse.kt
@@ -12,5 +12,4 @@ data class SignInResponse(
     val refreshTokenExp: LocalDateTime,
 
     val isExist: Boolean
-
 )

--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/filter/CookieJwtFilter.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/filter/CookieJwtFilter.kt
@@ -23,7 +23,7 @@ class CookieJwtFilter(
         filterChain.doFilter(request, response)
     }
 
-    private fun  resolvedToken(request: HttpServletRequest): String? =
+    private fun resolvedToken(request: HttpServletRequest): String? =
         request.cookies
-            ?.find { it.name == "Authorization" }?.value
+            ?.find { it.name == "accessToken" || it.name == "refreshToken" }?.value
 }

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/auth/AuthWebAdapter.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/auth/AuthWebAdapter.kt
@@ -9,6 +9,7 @@ import team.msg.sms.domain.auth.usecase.LogoutUseCase
 import team.msg.sms.domain.auth.usecase.ReIssueTokenUseCase
 import team.msg.sms.domain.auth.usecase.SignInUseCase
 import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import javax.validation.Valid
 
@@ -42,14 +43,31 @@ class AuthWebAdapter(
             .let { ResponseEntity.ok(it) }
 
     @DeleteMapping
-    fun logout(@Valid @RequestHeader("Refresh-Token") refreshToken: String): ResponseEntity<Void> =
-        logoutUseCase.execute(refreshToken)
-            .let { ResponseEntity.ok().build() }
+    fun logout(
+        @Valid @RequestHeader(name = "Refresh-Token", required = false) refreshToken: String?,
+        httpServletResponse: HttpServletResponse
+    ): ResponseEntity<Void> {
+        if (refreshToken != null) logoutUseCase.execute(refreshToken)
+        else {
+            val accessCookie: Cookie = expiredCookie(httpServletResponse, "accessToken")
+            val refreshCookie: Cookie = expiredCookie(httpServletResponse, "refreshToken")
+
+            httpServletResponse.addCookie(accessCookie)
+            httpServletResponse.addCookie(refreshCookie)
+        }
+        return ResponseEntity.ok().build()
+    }
 
     private fun createCookie(value: String, token: String, maxAge: Int): Cookie {
         val cookie = Cookie(value, token)
         cookie.isHttpOnly = true
         cookie.maxAge = maxAge
+        return cookie
+    }
+
+    private fun expiredCookie(httpServletResponse: HttpServletResponse, name: String): Cookie {
+        val cookie: Cookie = Cookie(name, null)
+        cookie.maxAge = 0
         return cookie
     }
 }

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/auth/AuthWebAdapter.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/auth/AuthWebAdapter.kt
@@ -8,6 +8,8 @@ import team.msg.sms.domain.auth.dto.response.SignInResponse
 import team.msg.sms.domain.auth.usecase.LogoutUseCase
 import team.msg.sms.domain.auth.usecase.ReIssueTokenUseCase
 import team.msg.sms.domain.auth.usecase.SignInUseCase
+import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServletResponse
 import javax.validation.Valid
 
 @RestController
@@ -15,13 +17,24 @@ import javax.validation.Valid
 class AuthWebAdapter(
     private val signInUseCase: SignInUseCase,
     private val reIssueTokenUseCase: ReIssueTokenUseCase,
-    private val logoutUseCase: LogoutUseCase
+    private val logoutUseCase: LogoutUseCase,
 ) {
 
     @PostMapping
-    fun signIn(@Valid @RequestBody request: SignInRequest): ResponseEntity<SignInResponse> =
-        signInUseCase.execute(request.toData())
-            .let { ResponseEntity.ok(it) }
+    fun signIn(
+        @Valid @RequestBody request: SignInRequest,
+        httpServletResponse: HttpServletResponse
+    ): ResponseEntity<SignInResponse> {
+        val token: SignInResponse = signInUseCase.execute(request.toData())
+
+        val accessCookie: Cookie = createCookie("accessToken", token.accessToken, 3600)
+        val refreshCookie: Cookie = createCookie("refreshToken", token.refreshToken, 36000)
+
+        httpServletResponse.addCookie(accessCookie)
+        httpServletResponse.addCookie(refreshCookie)
+
+        return ResponseEntity.ok(token)
+    }
 
     @PatchMapping
     fun reIssueToken(@Valid @RequestHeader("Refresh-Token") header: String): ResponseEntity<ReIssueTokenResponse> =
@@ -32,4 +45,11 @@ class AuthWebAdapter(
     fun logout(@Valid @RequestHeader("Refresh-Token") refreshToken: String): ResponseEntity<Void> =
         logoutUseCase.execute(refreshToken)
             .let { ResponseEntity.ok().build() }
+
+    private fun createCookie(value: String, token: String, maxAge: Int): Cookie {
+        val cookie = Cookie(value, token)
+        cookie.isHttpOnly = true
+        cookie.maxAge = maxAge
+        return cookie
+    }
 }

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/auth/AuthWebAdapter.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/auth/AuthWebAdapter.kt
@@ -28,11 +28,8 @@ class AuthWebAdapter(
     ): ResponseEntity<SignInResponse> {
         val token: SignInResponse = signInUseCase.execute(request.toData())
 
-        val accessCookie: Cookie = createCookie("accessToken", token.accessToken, 3600)
-        val refreshCookie: Cookie = createCookie("refreshToken", token.refreshToken, 36000)
-
-        httpServletResponse.addCookie(accessCookie)
-        httpServletResponse.addCookie(refreshCookie)
+        createCookie(httpServletResponse, "accessToken", token.accessToken, 3600)
+        createCookie(httpServletResponse, "refreshToken", token.refreshToken, 36000)
 
         return ResponseEntity.ok(token)
     }
@@ -49,25 +46,22 @@ class AuthWebAdapter(
     ): ResponseEntity<Void> {
         if (refreshToken != null) logoutUseCase.execute(refreshToken)
         else {
-            val accessCookie: Cookie = expiredCookie(httpServletResponse, "accessToken")
-            val refreshCookie: Cookie = expiredCookie(httpServletResponse, "refreshToken")
-
-            httpServletResponse.addCookie(accessCookie)
-            httpServletResponse.addCookie(refreshCookie)
+            expiredCookie(httpServletResponse, "accessToken")
+            expiredCookie(httpServletResponse, "refreshToken")
         }
         return ResponseEntity.ok().build()
     }
 
-    private fun createCookie(value: String, token: String, maxAge: Int): Cookie {
+    private fun createCookie(httpServletResponse: HttpServletResponse, value: String, token: String, maxAge: Int) {
         val cookie = Cookie(value, token)
         cookie.isHttpOnly = true
         cookie.maxAge = maxAge
-        return cookie
+        httpServletResponse.addCookie(cookie)
     }
 
-    private fun expiredCookie(httpServletResponse: HttpServletResponse, name: String): Cookie {
+    private fun expiredCookie(httpServletResponse: HttpServletResponse, name: String) {
         val cookie: Cookie = Cookie(name, null)
         cookie.maxAge = 0
-        return cookie
+        httpServletResponse.addCookie(cookie)
     }
 }


### PR DESCRIPTION
## 💡 개요

## 📃 작업내용
로그인시 토큰을 cookie로도 받을 수 있도록 추가하였습니다
로그아웃시 토큰과 헤더의 차이를 두었습니다
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
