### PR TITLE
🔀 :: page 500 에러 해결

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/FindAllUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/FindAllUseCase.kt
@@ -42,16 +42,16 @@ class FindAllUseCase(
 }
 
 fun List<Student.StudentWithUserInfo>.toDomainPageWithUserInfo(page: Int, size: Int): Student.StudentWithPageInfo {
-    val startIndex = page * size
+    val startIndex = (page - 1) * size
     val endIndex = (startIndex + size).coerceAtMost(this.size)
-    val content = this.subList(startIndex, endIndex)
+    val content = if (startIndex <= endIndex) this.subList(startIndex, endIndex) else emptyList()
 
     val totalPages = (this.size + size - 1) / size
-    val isLast = page >= totalPages - 1
+    val isLast = page >= totalPages
 
     return Student.StudentWithPageInfo(
         students = content,
-        page = page + 1,
+        page = page,
         contentSize = content.size,
         totalSize = this.size.toLong(),
         last = isLast


### PR DESCRIPTION
## 💡 개요
page 500 에러 해결
## 📃 작업내용
page 값이 0일 때 500 나게 변경 후 
page 값이 1일 때 성공 + page 값이 늘어나도 데이터가 없을 시 빈배열 데이터 전송