### PR TITLE
🔀 :: 189 - 현재 DTO 네이밍 일치

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/dto/req/SignUpRequestData.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/dto/req/SignUpRequestData.kt
@@ -15,11 +15,11 @@ data class SignUpRequestData(
     val contactEmail: String,
     val formOfEmployment: FormOfEmployment,
     val gsmAuthenticationScore: Int,
-    val region: List<String>,
+    val regions: List<String>,
     val salary: Int,
-    val languageCertificate: List<LanguageCertificateRequestData>,
+    val languageCertificates: List<LanguageCertificateRequestData>,
     val militaryService: MilitaryService,
-    val certificate: List<String>,
+    val certificates: List<String>,
     val projects: List<ProjectRequestData>,
     val prizes: List<PrizeRequestData>
 )

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/SignUpUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/SignUpUseCase.kt
@@ -85,19 +85,19 @@ class SignUpUseCase(
         }
 
         saveAllIfNotEmpty(
-            signUpData.region,
+            signUpData.regions,
             { toRegionModel(region = it, studentId = student.id) },
             regionService::saveAll
         )
 
         saveAllIfNotEmpty(
-            signUpData.languageCertificate,
+            signUpData.languageCertificates,
             { toLanguageCertificate(languageCertificate = it, studentId = student.id) },
             languageCertificateService::saveAll
         )
 
         saveAllIfNotEmpty(
-            signUpData.certificate,
+            signUpData.certificates,
             { toCertificate(certificate = it, studentId = student.id) },
             certificateService::saveAll
         )

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/student/dto/req/SignUpWebRequest.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/student/dto/req/SignUpWebRequest.kt
@@ -27,7 +27,7 @@ data class SignUpWebRequest(
     @field:Email
     val contactEmail: String,
 
-    val region: List<String>,
+    val regions: List<String>,
 
     val formOfEmployment: FormOfEmployment,
 
@@ -37,11 +37,11 @@ data class SignUpWebRequest(
     @field:NotNull
     val salary: Int,
 
-    val languageCertificate: List<LanguageCertificateWebRequest>,
+    val languageCertificates: List<LanguageCertificateWebRequest>,
 
     val militaryService: MilitaryService,
 
-    val certificate: List<String>,
+    val certificates: List<String>,
 
     val projects: List<ProjectRequestData>,
 
@@ -57,11 +57,11 @@ data class SignUpWebRequest(
             contactEmail = contactEmail,
             formOfEmployment = formOfEmployment,
             gsmAuthenticationScore = gsmAuthenticationScore,
-            region = region,
+            regions = regions,
             salary = salary,
-            languageCertificate = languageCertificate.map { it.toData() },
+            languageCertificates = languageCertificates.map { it.toData() },
             militaryService = militaryService,
-            certificate = certificate,
+            certificates = certificates,
             projects = projects,
             prizes = prizes
         )


### PR DESCRIPTION
## 💡 개요

## 📃 작업내용

## 🔀 변경사항
정보기입 시 이제 
region -> regions,
certificate -> certificates
languageCertificate -> languageCertificates
로 변경하셔야 합니다
## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
