### PR TITLE
🔀 :: image delete error

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/ModifyStudentInfoUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/ModifyStudentInfoUseCase.kt
@@ -231,7 +231,7 @@ class ModifyStudentInfoUseCase(
             saveProjectImages(checkAddedImages, projectModifyId)
 
             val checkRemovedImages = imageService.checkRemovedImage(images, modifyProject.previewImages)
-            deleteProjectImages(checkRemovedImages, projectModify)
+            deleteProjectImages(checkRemovedImages, projectModify.copy(id = projectModifyId))
         }
     }
 

--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/thirdparty/aws/stroage/AwsS3Adapter.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/thirdparty/aws/stroage/AwsS3Adapter.kt
@@ -10,15 +10,19 @@ import team.msg.sms.domain.file.exception.FileIOInterruptedException
 import team.msg.sms.domain.file.spi.UploadFilePort
 import java.io.File
 import java.io.IOException
+import java.util.*
 
 @Component
 class AwsS3Adapter(
     private val amazonS3: AmazonS3,
     private val awsS3Properties: AwsS3Properties
 ) : UploadFilePort {
-    override fun upload(file: File): String =
-        inputS3(file, file.name)
-            .run { getResourceUrl(fileName = file.name) }
+    override fun upload(file: File): String {
+        val fileName = "${UUID.randomUUID().toString()}.${file.extension}"
+        
+        return inputS3(file, fileName)
+            .run { getResourceUrl(fileName = fileName) }
+    }
 
     private fun inputS3(file: File, fileName: String) {
         val objectMetadata = ObjectMetadata()


### PR DESCRIPTION
## 💡 개요
이미지를 수정하는 곳에서 삭제할 때 project id 를 못찾아 오류가 났었습니다.

## 📃 작업내용
project id 값을 가진 project 를 copy 하여 데이터를 전송해주어 오류를 해결했습니다.

## 🔀 변경사항
 + 추가로 이미지가 한글 이름일 경우 DB에 데이터 최대길이가 255로 책정되어 too long 오류가 발생하여 이를 UUID 값으로 설정하여 저희가 길이를 관리할 수 있게 변경하였습니다.
## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
