### PR TITLE
🔀 :: 160 - try catch로 처리되어 있던 gAuth 로그인 로직을 runCathing으로 변경하였습니다

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/major/service/impl/GetMajorServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/major/service/impl/GetMajorServiceImpl.kt
@@ -6,7 +6,7 @@ import team.msg.sms.domain.major.service.GetMajorService
 import team.msg.sms.domain.major.spi.MajorPort
 
 @Service
-class QueryMajorServiceImpl(
+class GetMajorServiceImpl(
     private val majorPort: MajorPort
 ) : GetMajorService {
     override fun getAllMajor(): List<Major> =


### PR DESCRIPTION
## 💡 개요

## 📃 작업내용

## 🔀 변경사항
``` kt
fun execute(request: SignInRequestData): SignInResponseData {
        try {
            val gAuthToken = gAuthPort.receiveGAuthToken(request.code)
            val gAuthUserInfo = gAuthPort.receiveUserInfo(gAuthToken.accessToken)

            val role = userService.getRoleByGAuthInfo(gAuthUserInfo.email, gAuthUserInfo.role)

            val isExistsUser = userService.checkUserExistByEmail(gAuthUserInfo.email)
            val user = userService.createUserWhenNotExistUser(
                isExistsUser,
                User(
                    name = gAuthUserInfo.name,
                    email = gAuthUserInfo.email,
                    stuNum = getStuNumValid(role, gAuthUserInfo),
                    roles = mutableListOf(role)
                )
            )

            val (accessToken, accessTokenExp, refreshToken, refreshTokenExp) = jwtPort.receiveToken(user.id, role)

            refreshTokenPort.saveRefreshToken(RefreshToken(refreshToken, user.id))

            val isStudent = studentService.checkNewStudent(user, role.name)

            return SignInResponseData(
                accessToken = accessToken,
                accessTokenExp = accessTokenExp,
                refreshToken = refreshToken,
                refreshTokenExp = refreshTokenExp,
                role = role,
                isExist = isStudent
            )
        } catch (error: GAuthException) {
            when (error.code) {
                400 -> throw SecretMismatchException
                401 -> throw ExpiredCodeException
                404 -> throw ServiceNotFoundException
                else -> throw InternalServerErrorException
            }
        }
    }
```
을 
```kt
  fun execute(request: SignInRequestData): SignInResponseData =
        runCatching {
            val gAuthToken = gAuthPort.receiveGAuthToken(request.code)
            val gAuthUserInfo = gAuthPort.receiveUserInfo(gAuthToken.accessToken)

            val role = userService.getRoleByGAuthInfo(gAuthUserInfo.email, gAuthUserInfo.role)

            val isExistsUser = userService.checkUserExistByEmail(gAuthUserInfo.email)
            val user = userService.createUserWhenNotExistUser(
                isExistsUser,
                User(
                    name = gAuthUserInfo.name,
                    email = gAuthUserInfo.email,
                    stuNum = getStuNumValid(role, gAuthUserInfo),
                    roles = mutableListOf(role)
                )
            )

            val (accessToken, accessTokenExp, refreshToken, refreshTokenExp) = jwtPort.receiveToken(user.id, role)

            refreshTokenPort.saveRefreshToken(RefreshToken(refreshToken, user.id))

            val isStudent = studentService.checkNewStudent(user, role.name)

            SignInResponseData(
                accessToken = accessToken,
                accessTokenExp = accessTokenExp,
                refreshToken = refreshToken,
                refreshTokenExp = refreshTokenExp,
                role = role,
                isExist = isStudent
            )
        }.getOrElse { error ->
            when (error) {
                is GAuthException -> {
                    when (error.code) {
                        400 -> throw SecretMismatchException
                        401 -> throw ExpiredCodeException
                        404 -> throw ServiceNotFoundException
                        else -> throw InternalServerErrorException
                    }
                }
                else -> throw error
            }
        }
}
``` 로 변경하였습니다.

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
