### PR TITLE
🔀 :: 233 - 회원탈퇴 부분 쿼리 여러개 나가던 이슈 해결

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/certificate/service/CommandCertificateService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/certificate/service/CommandCertificateService.kt
@@ -6,6 +6,5 @@ import team.msg.sms.domain.student.model.Student
 interface CommandCertificateService {
     fun saveAll(certificate: List<Certificate>): List<Certificate>
     fun deleteAllByStudent(student: Student)
-
     fun deleteByCertificate(certificate: Certificate, student: Student)
 }

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/certificate/CertificatePersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/certificate/CertificatePersistenceAdapter.kt
@@ -1,11 +1,13 @@
 package team.msg.sms.persistence.certificate
 
+import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import team.msg.sms.domain.certificate.model.Certificate
 import team.msg.sms.domain.certificate.spi.CertificatePort
 import team.msg.sms.domain.student.exception.StudentNotFoundException
 import team.msg.sms.domain.student.model.Student
+import team.msg.sms.persistence.certificate.entity.QCertificateJpaEntity
 import team.msg.sms.persistence.certificate.mapper.toDomain
 import team.msg.sms.persistence.certificate.mapper.toEntity
 import team.msg.sms.persistence.certificate.repository.CertificateJpaRepository
@@ -15,7 +17,8 @@ import java.util.*
 @Component
 class CertificatePersistenceAdapter(
     private val certificateJpaRepository: CertificateJpaRepository,
-    private val studentJpaRepository: StudentJpaRepository
+    private val studentJpaRepository: StudentJpaRepository,
+    private val jpaQueryFactory: JPAQueryFactory
 ) : CertificatePort {
     override fun saveAll(certificate: List<Certificate>): List<Certificate> {
         val student = studentJpaRepository.findByIdOrNull(certificate.first().studentId)
@@ -28,7 +31,11 @@ class CertificatePersistenceAdapter(
     override fun deleteAllByStudent(student: Student) {
         val student = studentJpaRepository.findByIdOrNull(student.id)
             ?: throw StudentNotFoundException
-        certificateJpaRepository.deleteAllByStudent(student)
+        val certificate = QCertificateJpaEntity.certificateJpaEntity
+        jpaQueryFactory
+            .delete(certificate)
+            .where(certificate.student.id.eq(student.id))
+            .execute()
     }
 
     override fun deleteByCertificate(certificate: Certificate, student: Student) {

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/languagecertificate/LanguageCertificatePersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/languagecertificate/LanguageCertificatePersistenceAdapter.kt
@@ -1,11 +1,13 @@
 package team.msg.sms.persistence.languagecertificate
 
+import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import team.msg.sms.domain.languagecertificate.model.LanguageCertificate
 import team.msg.sms.domain.languagecertificate.spi.LanguageCertificatePort
 import team.msg.sms.domain.student.exception.StudentNotFoundException
 import team.msg.sms.domain.student.model.Student
+import team.msg.sms.persistence.languagecertificate.entity.QLanguageCertificateJpaEntity
 import team.msg.sms.persistence.languagecertificate.mapper.toDomain
 import team.msg.sms.persistence.languagecertificate.mapper.toEntity
 import team.msg.sms.persistence.languagecertificate.repository.LanguageCertificateJpaRepository
@@ -15,7 +17,8 @@ import java.util.*
 @Component
 class LanguageCertificatePersistenceAdapter(
     private val languageCertificateJpaRepository: LanguageCertificateJpaRepository,
-    private val studentJpaRepository: StudentJpaRepository
+    private val studentJpaRepository: StudentJpaRepository,
+    private val jpaQueryFactory: JPAQueryFactory
 ) : LanguageCertificatePort {
     override fun saveAll(languageCertificates: List<LanguageCertificate>): List<LanguageCertificate> {
         val student = studentJpaRepository.findByIdOrNull(languageCertificates.first().studentId)
@@ -28,13 +31,17 @@ class LanguageCertificatePersistenceAdapter(
     override fun deleteAllByStudent(student: Student) {
         val student = studentJpaRepository.findByIdOrNull(student.id)
             ?: throw StudentNotFoundException
-        languageCertificateJpaRepository.deleteAllByStudent(student)
+        val languageCertificate = QLanguageCertificateJpaEntity.languageCertificateJpaEntity
+        jpaQueryFactory
+            .delete(languageCertificate)
+            .where(languageCertificate.student.id.eq(student.id))
+            .execute()
     }
 
     override fun deleteByLanguageCertificate(languageCertificate: LanguageCertificate, student: Student) {
         val student = studentJpaRepository.findByIdOrNull(student.id)
             ?: throw StudentNotFoundException
-        languageCertificateJpaRepository.delete(languageCertificate.toEntity(student))
+            languageCertificateJpaRepository.delete(languageCertificate.toEntity(student))
     }
 
     override fun queryByStudentUuid(uuid: UUID): List<LanguageCertificate> =

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/prize/PrizePersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/prize/PrizePersistenceAdapter.kt
@@ -1,11 +1,13 @@
 package team.msg.sms.persistence.prize
 
+import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import team.msg.sms.domain.prize.model.Prize
 import team.msg.sms.domain.prize.spi.PrizePort
 import team.msg.sms.domain.student.exception.StudentNotFoundException
 import team.msg.sms.domain.student.model.Student
+import team.msg.sms.persistence.prize.entity.QPrizeJpaEntity
 import team.msg.sms.persistence.prize.mapper.toDomain
 import team.msg.sms.persistence.prize.mapper.toEntity
 import team.msg.sms.persistence.prize.repository.PrizeJpaRepository
@@ -15,7 +17,8 @@ import java.util.*
 @Component
 class PrizePersistenceAdapter(
     private val prizeJpaRepository: PrizeJpaRepository,
-    private val studentJpaRepository: StudentJpaRepository
+    private val studentJpaRepository: StudentJpaRepository,
+    private val jpaQueryFactory: JPAQueryFactory
 ) : PrizePort {
     override fun saveAll(prizes: List<Prize>) {
         val student = studentJpaRepository.findByIdOrNull(prizes.first().studentId)
@@ -31,7 +34,11 @@ class PrizePersistenceAdapter(
     override fun deleteAllByStudent(student: Student) {
         val student = studentJpaRepository.findByIdOrNull(student.id)
             ?: throw StudentNotFoundException
-        prizeJpaRepository.deleteAllByStudent(student)
+        val prize = QPrizeJpaEntity.prizeJpaEntity
+        jpaQueryFactory
+            .delete(prize)
+            .where(prize.student.id.eq(student.id))
+            .execute()
     }
 
     override fun deleteByPrize(prize: Prize, student: Student) {

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/region/RegionPersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/region/RegionPersistenceAdapter.kt
@@ -1,11 +1,13 @@
 package team.msg.sms.persistence.region
 
+import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import team.msg.sms.domain.region.model.Region
 import team.msg.sms.domain.region.spi.RegionPort
 import team.msg.sms.domain.student.exception.StudentNotFoundException
 import team.msg.sms.domain.student.model.Student
+import team.msg.sms.persistence.region.entity.QRegionJpaEntity
 import team.msg.sms.persistence.region.mapper.toDomain
 import team.msg.sms.persistence.region.mapper.toEntity
 import team.msg.sms.persistence.region.repository.RegionJpaRepository
@@ -15,7 +17,8 @@ import java.util.*
 @Component
 class RegionPersistenceAdapter(
     private val regionJpaRepository: RegionJpaRepository,
-    private val studentJpaRepository: StudentJpaRepository
+    private val studentJpaRepository: StudentJpaRepository,
+    private val jpaQueryFactory: JPAQueryFactory
 ) : RegionPort {
     override fun saveAll(regions: List<Region>): List<Region> {
         val student = studentJpaRepository.findByIdOrNull(regions.first().studentId)
@@ -28,7 +31,11 @@ class RegionPersistenceAdapter(
     override fun deleteAllByStudent(student: Student) {
         val student = studentJpaRepository.findByIdOrNull(student.id)
             ?: throw StudentNotFoundException
-        regionJpaRepository.deleteAllByStudent(student)
+        val region = QRegionJpaEntity.regionJpaEntity
+        jpaQueryFactory
+            .delete(region)
+            .where(region.student.eq(student))
+            .execute()
     }
 
     override fun queryByStudentUuid(uuid: UUID): List<Region> =

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/student/StudentTechStackPersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/student/StudentTechStackPersistenceAdapter.kt
@@ -1,5 +1,6 @@
 package team.msg.sms.persistence.student
 
+import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import team.msg.sms.domain.student.exception.StudentNotFoundException
@@ -7,6 +8,7 @@ import team.msg.sms.domain.student.model.Student
 import team.msg.sms.domain.student.model.StudentTechStack
 import team.msg.sms.domain.student.spi.StudentTechStackPort
 import team.msg.sms.domain.techstack.model.TechStack
+import team.msg.sms.persistence.student.entity.QStudentTechStackJpaEntity
 import team.msg.sms.persistence.student.mapper.toDomain
 import team.msg.sms.persistence.student.mapper.toEntity
 import team.msg.sms.persistence.student.repository.StudentJpaRepository
@@ -18,7 +20,8 @@ import java.util.*
 class StudentTechStackPersistenceAdapter(
     private val studentTechStackJpaRepository: StudentTechStackJpaRepository,
     private val studentJpaRepository: StudentJpaRepository,
-    private val techStackJpaRepository: TechStackJpaRepository
+    private val techStackJpaRepository: TechStackJpaRepository,
+    private val jpaQueryFactory: JPAQueryFactory
 ) : StudentTechStackPort {
     override fun save(studentTechStack: StudentTechStack) {
         val student = studentJpaRepository.findByIdOrNull(studentTechStack.studentId)
@@ -35,7 +38,11 @@ class StudentTechStackPersistenceAdapter(
     override fun deleteAllByStudent(student: Student) {
         val student = studentJpaRepository.findByIdOrNull(student.id)
             ?: throw StudentNotFoundException
-        studentTechStackJpaRepository.deleteAllByStudent(student)
+        val studentTechStack = QStudentTechStackJpaEntity.studentTechStackJpaEntity
+        jpaQueryFactory
+            .delete(studentTechStack)
+            .where(studentTechStack.student.id.eq(student.id))
+            .execute()
     }
 
     override fun deleteByStudentAndTechStack(student: Student, techStack: TechStack) {


### PR DESCRIPTION
## 💡 개요
<img width="181" alt="스크린샷 2023-09-12 오후 3 12 42" src="https://github.com/GSM-MSG/SMS-BackEnd/assets/81404026/7d9cdc33-fbf1-460c-8482-31044371cb4f">. 
deleteAll 을 이용시 쿼리가 여러개 나가는 문제가 있어서 수정하였습니다.  

## 📃 작업내용
기존 deleteAll 함수를 QueryDSL을 이용하여 
<img width="305" alt="image" src="https://github.com/GSM-MSG/SMS-BackEnd/assets/81404026/39a932f6-b1cf-47ae-9fff-4e5049ebfed1">
  사용하여.
<img width="171" alt="image" src="https://github.com/GSM-MSG/SMS-BackEnd/assets/81404026/ee66c6f3-1982-4334-974f-cb0ee7e234fa">.   
쿼리를 줄였습니다
## 🔀 변경사항
기존 걸리던 시간이 600~700ms에서 90 ~ 100초반 까지 개선 되었습니다 (로컬기준)
## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
