### PR TITLE
🔀 250 :: Redis TTL 적용 오류 수정

### DIFF
--- a/sms-persistence/src/main/kotlin/team/msg/sms/global/config/RedisConfig.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/global/config/RedisConfig.kt
@@ -7,9 +7,12 @@ import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisKeyValueAdapter
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
 import java.time.Duration
 
 @Configuration
+@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
 class RedisConfig(
 
     @Value("\${spring.redis.host}")


### PR DESCRIPTION
## 💡 개요
Redis의 TTL 적용 오류를 수정했습니다.

## 📃 작업내용
https://wildeveloperetrain.tistory.com/273
위 글을 참고했습니다.

- Redis config에 @EnableRedisRepositories 추가
   - EnableKeyspaceEvents.ON_STARTUP 옵션 부여

## 🙋‍♂️ 질문사항

keyspace event 적용 전과 후의 저장 방식이 다른데, 그러면 이전에 있던 데이터에는 적용이 안되지 않을까요? 잔존하는 데이터들은 어떻게 하는 게 좋을까요?