### PR TITLE
선생님 회원가입을 위해 선생님 엔티티와 권한을 추가했습니다.

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/auth/model/Role.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/auth/model/Role.kt
@@ -2,5 +2,9 @@ package team.msg.sms.domain.auth.model
 
 enum class Role(description: String) {
     ROLE_STUDENT("학생"),
-    ROLE_TEACHER("선생님")
+    ROLE_TEACHER("선생님"),
+    ROLE_PRINCIPAL("교장선생님"),
+    ROLE_DEPUTY_PRINCIPAL("교감선생님"),
+    ROLE_DIRECTOR("부장선생님"),
+    ROLE_HOMEROOM("담임선생님")
 }

--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
@@ -19,6 +19,15 @@ class SecurityConfig(
     private val customAuthenticationEntryPoint: CustomAuthenticationEntryPoint
 ) {
 
+    companion object {
+        const val STUDENT = "ROLE_STUDENT" // 학생
+        const val TEACHER = "ROLE_TEACHER" // 선생님
+        const val PRINCIPAL = "ROLE_PRINCIPAL" // 교장선생님
+        const val DEPUTY_PRINCIPAL = "ROLE_DEPUTY_PRINCIPAL" // 교감선생님
+        const val DIRECTOR = "ROLE_DIRECTOR" // 부장선생님
+        const val HOMEROOM = "ROLE_HOMEROOM" // 담임선생님
+    }
+
     @Bean
     protected fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
@@ -47,11 +56,11 @@ class SecurityConfig(
             .antMatchers(HttpMethod.DELETE, "/auth/withdrawal").authenticated()
 
             .antMatchers(HttpMethod.GET, "/user/profile/img").permitAll()
-            .antMatchers(HttpMethod.GET,"/user/profile").hasAuthority("ROLE_STUDENT")
+            .antMatchers(HttpMethod.GET,"/user/profile").hasAuthority(STUDENT)
 
-            .antMatchers(HttpMethod.POST, "/student").hasAuthority("ROLE_STUDENT")
+            .antMatchers(HttpMethod.POST, "/student").hasAuthority(STUDENT)
             .antMatchers(HttpMethod.GET, "/student").permitAll()
-            .antMatchers(HttpMethod.GET, "/student/{uuid}").hasAnyAuthority("ROLE_STUDENT", "ROLE_TEACHER")
+            .antMatchers(HttpMethod.GET, "/student/{uuid}").hasAnyAuthority(STUDENT, TEACHER)
             .antMatchers(HttpMethod.GET, "/student/anonymous/{uuid}").permitAll()
 
             .antMatchers(HttpMethod.POST, "/file").authenticated()

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/entity/HomeroomTeacherJpaEntity.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/entity/HomeroomTeacherJpaEntity.kt
@@ -1,0 +1,20 @@
+package team.msg.sms.persistence.teacher.entity
+
+import team.msg.sms.persistence.BaseIdEntity
+import javax.persistence.*
+
+@Entity
+@Table(name = "homeroom_teacher")
+class HomeroomTeacherJpaEntity (
+    override val id: Long,
+
+    @Column
+    val grade: Int,
+
+    @Column(name = "class_name")
+    val classNum: Int,
+
+    @OneToOne(cascade = [CascadeType.ALL])
+    @JoinColumn(name = "teacher_id")
+    val teacher: TeacherJpaEntity
+) : BaseIdEntity()

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/entity/HomeroomTeacherJpaEntity.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/entity/HomeroomTeacherJpaEntity.kt
@@ -11,7 +11,7 @@ class HomeroomTeacherJpaEntity (
     @Column
     val grade: Int,
 
-    @Column(name = "class_name")
+    @Column(name = "class_num")
     val classNum: Int,
 
     @OneToOne(cascade = [CascadeType.ALL])

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/entity/TeacherJpaEntity.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/entity/TeacherJpaEntity.kt
@@ -1,0 +1,19 @@
+package team.msg.sms.persistence.teacher.entity
+
+import team.msg.sms.persistence.BaseUuidEntity
+import team.msg.sms.persistence.user.entity.UserJpaEntity
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.JoinColumn
+import javax.persistence.OneToOne
+import javax.persistence.Table
+
+@Entity
+@Table(name = "teacher")
+class TeacherJpaEntity (
+    override val id: UUID,
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    val user: UserJpaEntity
+) : BaseUuidEntity(id)

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/repository/HomeroomTeacherJpaRepository.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/repository/HomeroomTeacherJpaRepository.kt
@@ -1,0 +1,8 @@
+package team.msg.sms.persistence.teacher.repository
+
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+import team.msg.sms.persistence.teacher.entity.HomeroomTeacherJpaEntity
+
+@Repository
+interface HomeroomTeacherJpaRepository : CrudRepository<HomeroomTeacherJpaEntity, Long>

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/repository/TeacherJpaRepository.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/repository/TeacherJpaRepository.kt
@@ -1,0 +1,9 @@
+package team.msg.sms.persistence.teacher.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import team.msg.sms.persistence.teacher.entity.TeacherJpaEntity
+import java.util.*
+
+@Repository
+interface TeacherJpaRepository : JpaRepository<TeacherJpaEntity, UUID>


### PR DESCRIPTION
## 💡 개요
- 선생님 회원가입을 위해 선생님 엔티티와 권한을 추가했습니다.

## 📃 작업내용
선생님 엔티티와 담임 선생님 엔티티를 생성했습니다.
- 담임선생님 엔티티의 id는 노출될 일이 없기 때문에 UUID가 아닌 Long 타입으로 설정해주었습니다.

## 🔀 변경사항
- 페이지 별 권한을 문자열로 작성하던 걸 상수로 변경해주었습니다.
