### PR TITLE
담임선생님으로 가입 api를 작성했습니다.

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/auth/usecase/VerifyAccessUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/auth/usecase/VerifyAccessUseCase.kt
@@ -8,6 +8,10 @@ import team.msg.sms.domain.user.service.UserService
 class VerifyAccessUseCase(
     private val userService: UserService
 ) {
+    /**
+     * Role에 대한 반환 타입이 list가 아닌 단일 string이라 슬래시로 구분해두었습니다.
+     * 추후 response를 변경하게 되면 바꿔도 괜찮을 거 같아요!
+     */
     fun execute(): VerifyAccessResponseData =
         userService.getCurrentUser()
             .let {

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/auth/usecase/VerifyAccessUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/auth/usecase/VerifyAccessUseCase.kt
@@ -13,7 +13,7 @@ class VerifyAccessUseCase(
             .let {
                 VerifyAccessResponseData(
                     userService.checkNewUser(it),
-                    it.roles[0].name
+                    it.roles.joinToString("/")
                 )
             }
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/dto/req/SignUpHomeroomTeacherRequestData.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/dto/req/SignUpHomeroomTeacherRequestData.kt
@@ -1,0 +1,6 @@
+package team.msg.sms.domain.teacher.dto.req
+
+data class SignUpHomeroomTeacherRequestData(
+    val grade: Int,
+    val classNum: Int
+)

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/exception/HomeroomTeacherAlreadyException.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/exception/HomeroomTeacherAlreadyException.kt
@@ -1,0 +1,8 @@
+package team.msg.sms.domain.teacher.exception
+
+import team.msg.sms.common.error.SmsException
+import team.msg.sms.domain.teacher.exception.error.TeacherErrorCode
+
+object HomeroomTeacherAlreadyException : SmsException(
+    TeacherErrorCode.HOMEROOM_TEACHER_ALREADY
+)

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/exception/error/TeacherErrorCode.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/exception/error/TeacherErrorCode.kt
@@ -8,7 +8,8 @@ enum class TeacherErrorCode(
     private val message: String
 ) : ErrorProperty {
 
-    TEACHER_ALREADY(ErrorStatus.CONFLICT, "선생님 정보가 존재하는 유저입니다"),
+    TEACHER_ALREADY(ErrorStatus.CONFLICT, "선생님 정보가 존재하는 유저입니다."),
+    HOMEROOM_TEACHER_ALREADY(ErrorStatus.CONFLICT, "동일 정보의 담임선생님이 존재합니다."),
     ;
 
     override fun status(): Int = status

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/model/HomeroomTeacher.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/model/HomeroomTeacher.kt
@@ -5,7 +5,7 @@ import java.util.*
 
 @Aggregate
 data class HomeroomTeacher (
-    val id: Long,
+    val id: Long = 0,
     val grade: Int,
     val classNum: Int,
     val teacherId: UUID,

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/CheckHomeroomTeacherService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/CheckHomeroomTeacherService.kt
@@ -1,5 +1,5 @@
 package team.msg.sms.domain.teacher.service
 
 interface CheckHomeroomTeacherService {
-    fun checkHomeroomTeacherExistsByTeacher(grade: Int, classNum: Int)
+    fun checkHomeroomTeacherExistsByGradeAndClassNum(grade: Int, classNum: Int)
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/CheckHomeroomTeacherService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/CheckHomeroomTeacherService.kt
@@ -3,5 +3,5 @@ package team.msg.sms.domain.teacher.service
 import team.msg.sms.domain.teacher.model.Teacher
 
 interface CheckHomeroomTeacherService {
-    fun checkTeacherExistsByTeacher(teacher: Teacher)
+    fun checkHomeroomTeacherExistsByTeacher(teacher: Teacher)
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/CheckHomeroomTeacherService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/CheckHomeroomTeacherService.kt
@@ -1,7 +1,5 @@
 package team.msg.sms.domain.teacher.service
 
-import team.msg.sms.domain.teacher.model.Teacher
-
 interface CheckHomeroomTeacherService {
-    fun checkHomeroomTeacherExistsByTeacher(teacher: Teacher)
+    fun checkHomeroomTeacherExistsByTeacher(grade: Int, classNum: Int)
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/CheckHomeroomTeacherService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/CheckHomeroomTeacherService.kt
@@ -1,0 +1,7 @@
+package team.msg.sms.domain.teacher.service
+
+import team.msg.sms.domain.teacher.model.Teacher
+
+interface CheckHomeroomTeacherService {
+    fun checkTeacherExistsByTeacher(teacher: Teacher)
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/CommandHomeroomTeacherService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/CommandHomeroomTeacherService.kt
@@ -2,7 +2,8 @@ package team.msg.sms.domain.teacher.service
 
 import team.msg.sms.domain.teacher.model.HomeroomTeacher
 import team.msg.sms.domain.teacher.model.Teacher
+import team.msg.sms.domain.user.model.User
 
 interface CommandHomeroomTeacherService {
-    fun saveHomeroomTeacher(homeroomTeacher: HomeroomTeacher, teacher: Teacher)
+    fun saveHomeroomTeacher(homeroomTeacher: HomeroomTeacher, teacher: Teacher, user: User)
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/CommandHomeroomTeacherService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/CommandHomeroomTeacherService.kt
@@ -1,0 +1,8 @@
+package team.msg.sms.domain.teacher.service
+
+import team.msg.sms.domain.teacher.model.HomeroomTeacher
+import team.msg.sms.domain.teacher.model.Teacher
+
+interface CommandHomeroomTeacherService {
+    fun saveHomeroomTeacher(homeroomTeacher: HomeroomTeacher, teacher: Teacher)
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/CommandTeacherService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/CommandTeacherService.kt
@@ -1,7 +1,8 @@
 package team.msg.sms.domain.teacher.service
 
+import team.msg.sms.domain.teacher.model.Teacher
 import team.msg.sms.domain.user.model.User
 
 interface CommandTeacherService {
-    fun saveTeacher(user: User)
+    fun saveTeacher(user: User): Teacher
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/HomeroomTeacherService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/HomeroomTeacherService.kt
@@ -1,0 +1,10 @@
+package team.msg.sms.domain.teacher.service
+
+import team.msg.sms.common.annotation.Service
+
+@Service
+class HomeroomTeacherService (
+    checkHomeroomTeacherService: CheckHomeroomTeacherService,
+    commandHomeroomTeacherService: CommandHomeroomTeacherService
+) : CheckHomeroomTeacherService by checkHomeroomTeacherService,
+    CommandHomeroomTeacherService by commandHomeroomTeacherService

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/impl/CheckHomeroomTeacherServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/impl/CheckHomeroomTeacherServiceImpl.kt
@@ -1,0 +1,16 @@
+package team.msg.sms.domain.teacher.service.impl
+
+import team.msg.sms.common.annotation.Service
+import team.msg.sms.domain.teacher.exception.HomeroomTeacherAlreadyException
+import team.msg.sms.domain.teacher.service.CheckHomeroomTeacherService
+import team.msg.sms.domain.teacher.spi.HomeroomTeacherPort
+
+@Service
+class CheckHomeroomTeacherServiceImpl(
+    private val homeroomTeacherPort: HomeroomTeacherPort
+) : CheckHomeroomTeacherService {
+    override fun checkHomeroomTeacherExistsByGradeAndClassNum(grade: Int, classNum: Int) {
+        if (homeroomTeacherPort.existsHomeroomTeacherByGradeAndClassNum(grade, classNum))
+            throw HomeroomTeacherAlreadyException
+    }
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/impl/CommandHomeroomTeacherServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/impl/CommandHomeroomTeacherServiceImpl.kt
@@ -1,0 +1,23 @@
+package team.msg.sms.domain.teacher.service.impl
+
+import team.msg.sms.common.annotation.Service
+import team.msg.sms.domain.auth.model.Role
+import team.msg.sms.domain.teacher.model.HomeroomTeacher
+import team.msg.sms.domain.teacher.model.Teacher
+import team.msg.sms.domain.teacher.service.CommandHomeroomTeacherService
+import team.msg.sms.domain.teacher.spi.HomeroomTeacherPort
+import team.msg.sms.domain.user.model.User
+import team.msg.sms.domain.user.spi.UserPort
+
+@Service
+class CommandHomeroomTeacherServiceImpl(
+    private val homeroomTeacherPort: HomeroomTeacherPort,
+    private val userPort: UserPort
+) : CommandHomeroomTeacherService {
+    override fun saveHomeroomTeacher(homeroomTeacher: HomeroomTeacher, teacher: Teacher, user: User) {
+        homeroomTeacherPort.saveHomeroomTeacher(homeroomTeacher, teacher, user)
+
+        user.roles.add(Role.ROLE_HOMEROOM)
+        userPort.saveUser(user)
+    }
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/impl/CommandTeacherServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/service/impl/CommandTeacherServiceImpl.kt
@@ -11,12 +11,12 @@ import java.util.*
 class CommandTeacherServiceImpl(
     private val teacherPort: TeacherPort
 ) : CommandTeacherService {
-    override fun saveTeacher(user: User) {
+    override fun saveTeacher(user: User): Teacher {
         val teacher = Teacher(
             id = UUID.randomUUID(),
             userId = user.id,
         )
 
-        teacherPort.saveTeacher(teacher, user)
+        return teacherPort.saveTeacher(teacher, user)
     }
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/spi/CommandHomeroomTeacherPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/spi/CommandHomeroomTeacherPort.kt
@@ -2,7 +2,8 @@ package team.msg.sms.domain.teacher.spi
 
 import team.msg.sms.domain.teacher.model.HomeroomTeacher
 import team.msg.sms.domain.teacher.model.Teacher
+import team.msg.sms.domain.user.model.User
 
 interface CommandHomeroomTeacherPort {
-    fun saveHomeroomTeacher(homeroomTeacher: HomeroomTeacher, teacher: Teacher)
+    fun saveHomeroomTeacher(homeroomTeacher: HomeroomTeacher, teacher: Teacher, user: User): HomeroomTeacher
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/spi/CommandHomeroomTeacherPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/spi/CommandHomeroomTeacherPort.kt
@@ -1,0 +1,8 @@
+package team.msg.sms.domain.teacher.spi
+
+import team.msg.sms.domain.teacher.model.HomeroomTeacher
+import team.msg.sms.domain.teacher.model.Teacher
+
+interface CommandHomeroomTeacherPort {
+    fun saveHomeroomTeacher(homeroomTeacher: HomeroomTeacher, teacher: Teacher)
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/spi/HomeroomTeacherPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/spi/HomeroomTeacherPort.kt
@@ -1,0 +1,5 @@
+package team.msg.sms.domain.teacher.spi
+
+interface HomeroomTeacherPort :
+        QueryHomeroomTeacherPort,
+        CommandHomeroomTeacherPort

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/spi/QueryHomeroomTeacherPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/spi/QueryHomeroomTeacherPort.kt
@@ -1,0 +1,5 @@
+package team.msg.sms.domain.teacher.spi
+
+interface QueryHomeroomTeacherPort {
+    fun existsHomeroomTeacherByGradeAndClassNum(grade: Int, classNum: Int): Boolean
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/usecase/SignUpHomeroomTeacherUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/usecase/SignUpHomeroomTeacherUseCase.kt
@@ -1,0 +1,23 @@
+package team.msg.sms.domain.teacher.usecase
+
+import org.springframework.transaction.annotation.Transactional
+import team.msg.sms.common.annotation.UseCase
+import team.msg.sms.domain.teacher.dto.req.SignUpHomeroomTeacherRequestData
+import team.msg.sms.domain.teacher.service.TeacherService
+import team.msg.sms.domain.user.service.UserService
+
+@UseCase
+class SignUpHomeroomTeacherUseCase(
+    private val userService: UserService,
+    private val teacherService: TeacherService
+) {
+
+    @Transactional(rollbackFor = [Exception::class])
+    fun execute(signUpHomeroomTeacherRequestData: SignUpHomeroomTeacherRequestData) {
+        val user = userService.getCurrentUser()
+
+        teacherService.checkTeacherExistsByUser(user)
+
+        teacherService.saveTeacher(user)
+    }
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/usecase/SignUpHomeroomTeacherUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/teacher/usecase/SignUpHomeroomTeacherUseCase.kt
@@ -3,13 +3,17 @@ package team.msg.sms.domain.teacher.usecase
 import org.springframework.transaction.annotation.Transactional
 import team.msg.sms.common.annotation.UseCase
 import team.msg.sms.domain.teacher.dto.req.SignUpHomeroomTeacherRequestData
+import team.msg.sms.domain.teacher.model.HomeroomTeacher
+import team.msg.sms.domain.teacher.service.CommandHomeroomTeacherService
+import team.msg.sms.domain.teacher.service.HomeroomTeacherService
 import team.msg.sms.domain.teacher.service.TeacherService
 import team.msg.sms.domain.user.service.UserService
 
 @UseCase
 class SignUpHomeroomTeacherUseCase(
     private val userService: UserService,
-    private val teacherService: TeacherService
+    private val teacherService: TeacherService,
+    private val homeroomTeacherService: HomeroomTeacherService
 ) {
 
     @Transactional(rollbackFor = [Exception::class])
@@ -18,6 +22,18 @@ class SignUpHomeroomTeacherUseCase(
 
         teacherService.checkTeacherExistsByUser(user)
 
-        teacherService.saveTeacher(user)
+        val teacher = teacherService.saveTeacher(user)
+        val grade = signUpHomeroomTeacherRequestData.grade
+        val classNum = signUpHomeroomTeacherRequestData.classNum
+
+        homeroomTeacherService.checkHomeroomTeacherExistsByGradeAndClassNum(grade, classNum)
+
+        val homeroomTeacher = HomeroomTeacher(
+            grade = grade,
+            classNum = classNum,
+            teacherId = teacher.id
+        )
+
+        homeroomTeacherService.saveHomeroomTeacher(homeroomTeacher, teacher, user)
     }
 }

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/HomeroomTeacherPersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/HomeroomTeacherPersistenceAdapter.kt
@@ -1,0 +1,22 @@
+package team.msg.sms.persistence.teacher
+
+import org.springframework.stereotype.Component
+import team.msg.sms.domain.teacher.model.HomeroomTeacher
+import team.msg.sms.domain.teacher.model.Teacher
+import team.msg.sms.domain.teacher.spi.HomeroomTeacherPort
+import team.msg.sms.domain.user.model.User
+import team.msg.sms.persistence.teacher.mapper.toDomain
+import team.msg.sms.persistence.teacher.mapper.toEntity
+import team.msg.sms.persistence.teacher.repository.HomeroomTeacherJpaRepository
+import team.msg.sms.persistence.user.mapper.toEntity
+
+@Component
+class HomeroomTeacherPersistenceAdapter(
+    private val homeroomTeacherJpaRepository: HomeroomTeacherJpaRepository
+) : HomeroomTeacherPort {
+    override fun existsHomeroomTeacherByGradeAndClassNum(grade: Int, classNum: Int): Boolean =
+        homeroomTeacherJpaRepository.existsByGradeAndClassNum(grade, classNum)
+
+    override fun saveHomeroomTeacher(homeroomTeacher: HomeroomTeacher, teacher: Teacher, user: User): HomeroomTeacher =
+        homeroomTeacherJpaRepository.save(homeroomTeacher.toEntity(teacher.toEntity(user.toEntity()))).toDomain()
+}

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/entity/HomeroomTeacherJpaEntity.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/entity/HomeroomTeacherJpaEntity.kt
@@ -14,7 +14,7 @@ class HomeroomTeacherJpaEntity (
     @Column(name = "class_num")
     val classNum: Int,
 
-    @OneToOne(cascade = [CascadeType.ALL])
+    @OneToOne
     @JoinColumn(name = "teacher_id")
     val teacher: TeacherJpaEntity
 ) : BaseIdEntity()

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/mapper/HomeroomTeacherMapper.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/mapper/HomeroomTeacherMapper.kt
@@ -1,0 +1,21 @@
+package team.msg.sms.persistence.teacher.mapper
+
+import team.msg.sms.domain.teacher.model.HomeroomTeacher
+import team.msg.sms.persistence.teacher.entity.HomeroomTeacherJpaEntity
+import team.msg.sms.persistence.teacher.entity.TeacherJpaEntity
+
+fun HomeroomTeacher.toEntity(teacher: TeacherJpaEntity) =
+    HomeroomTeacherJpaEntity(
+        id = id,
+        grade = grade,
+        classNum = classNum,
+        teacher = teacher
+    )
+
+fun HomeroomTeacherJpaEntity.toDomain() =
+    HomeroomTeacher(
+        id = id,
+        grade = grade,
+        classNum = classNum,
+        teacherId = teacher.id
+    )

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/repository/HomeroomTeacherJpaRepository.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/teacher/repository/HomeroomTeacherJpaRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.stereotype.Repository
 import team.msg.sms.persistence.teacher.entity.HomeroomTeacherJpaEntity
 
 @Repository
-interface HomeroomTeacherJpaRepository : CrudRepository<HomeroomTeacherJpaEntity, Long>
+interface HomeroomTeacherJpaRepository : CrudRepository<HomeroomTeacherJpaEntity, Long> {
+    fun existsByGradeAndClassNum(grade: Int, classNum: Int): Boolean
+}

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/teacher/TeacherWebAdapter.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/teacher/TeacherWebAdapter.kt
@@ -3,17 +3,27 @@ package team.msg.sms.domain.teacher
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import team.msg.sms.domain.teacher.dto.req.SignUpHomeroomTeacherWebRequest
+import team.msg.sms.domain.teacher.usecase.SignUpHomeroomTeacherUseCase
 import team.msg.sms.domain.teacher.usecase.SignUpTeacherUseCase
+import javax.validation.Valid
 
 @RestController
 @RequestMapping("/teacher")
 class TeacherWebAdapter(
-    private val signUpUseCase: SignUpTeacherUseCase
+    private val signUpTeacherUseCase: SignUpTeacherUseCase,
+    private val signUpHomeroomTeacherUseCase: SignUpHomeroomTeacherUseCase
 ) {
     @PostMapping("/common")
     fun signUpTeacher(): ResponseEntity<Unit> =
-        signUpUseCase.execute()
+        signUpTeacherUseCase.execute()
+            .let { ResponseEntity.status(HttpStatus.CREATED).build() }
+
+    @PostMapping("/homeroom")
+    fun signUpHomeroomTeacher(@RequestBody @Valid signUpHomeroomTeacherWebRequest: SignUpHomeroomTeacherWebRequest): ResponseEntity<Unit> =
+        signUpHomeroomTeacherUseCase.execute(signUpHomeroomTeacherWebRequest.toData())
             .let { ResponseEntity.status(HttpStatus.CREATED).build() }
 }

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/teacher/dto/req/SignUpHomeroomTeacherWebRequest.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/teacher/dto/req/SignUpHomeroomTeacherWebRequest.kt
@@ -14,4 +14,10 @@ data class SignUpHomeroomTeacherWebRequest(
     @field:Max(4)
     @field:NotNull
     val classNum: Int
-)
+) {
+    fun toData(): SignUpHomeroomTeacherRequestData =
+        SignUpHomeroomTeacherRequestData(
+            grade = grade,
+            classNum = classNum
+        )
+}

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/teacher/dto/req/SignUpHomeroomTeacherWebRequest.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/teacher/dto/req/SignUpHomeroomTeacherWebRequest.kt
@@ -1,0 +1,17 @@
+package team.msg.sms.domain.teacher.dto.req
+
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
+import javax.validation.constraints.NotNull
+
+data class SignUpHomeroomTeacherWebRequest(
+    @field:Min(1)
+    @field:Max(3)
+    @field:NotNull
+    val grade: Int,
+
+    @field:Min(1)
+    @field:Max(4)
+    @field:NotNull
+    val classNum: Int
+)


### PR DESCRIPTION
## 💡 개요
담임선생님으로 가입 api를 작성했습니다.

## 📃 작업내용
- HOMEROOM, 담임선생님 권한은 가지되 TEACHER, 선생님 권한도 가질 수 있도록 했습니다.
- 담임 중복 가입이 없도록 같은 학년, 반을 가지는 담임선생님의 회원가입을 막아두었습니다.

## 🔀 변경사항
권한을 중복으로 가질 수 있으니 권한들을 "/" 문자로 나누어 반환하도록 변경했습니다.

## 🎸 기타
3시간 동안 뭐가 문제지 하고 있었는디... 빌드 파일을 삭제하고 다시 빌드해보니 멀끔해진 오류창,... 덕분에 늦었습니다 😥
