### PR TITLE
인증제 활동 생성 api를 작성했습니다.

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/dto/req/CreateAuthenticationRequestData.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/dto/req/CreateAuthenticationRequestData.kt
@@ -1,0 +1,7 @@
+package team.msg.sms.domain.authentication.dto.req
+
+data class CreateAuthenticationRequestData (
+    val title: String,
+    val content: String,
+    val activityImages: List<String>
+)

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/dto/res/CreateAuthenticationResponseData.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/dto/res/CreateAuthenticationResponseData.kt
@@ -1,0 +1,7 @@
+package team.msg.sms.domain.authentication.dto.res
+
+import java.util.UUID
+
+data class CreateAuthenticationResponseData(
+    val id: UUID
+)

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/event/AuthenticationHistoryEvent.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/event/AuthenticationHistoryEvent.kt
@@ -1,0 +1,14 @@
+package team.msg.sms.domain.authentication.event
+
+import team.msg.sms.domain.authentication.model.Authentication
+import java.util.UUID
+
+/**
+ * 인증제 히스토리를 저장하는 event입니다.
+ * 인증제 활동이 저장되거나 변경될 때 발행됩니다.
+ */
+data class AuthenticationHistoryEvent (
+    val authentication: Authentication,
+    val reason: String,
+    val teacherId: UUID? = null
+)

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/handler/AuthenticationEventHandler.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/handler/AuthenticationEventHandler.kt
@@ -22,13 +22,10 @@ class AuthenticationEventHandler(
      */
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     fun authenticationHistoryHandler(event: AuthenticationHistoryEvent) {
-        println(1)
         val authentication = event.authentication
-        println(2)
-        val student = studentService.getStudentByUserId(authentication.studentId)
-        println(3)
+        val student = studentService.getStudentById(authentication.studentId)
         val studentUser = userService.getUserById(student.userId)
-        println(4)
+
         val history = AuthenticationHistory(
             reason = event.reason,
             activityStatus = authentication.activityStatus,
@@ -36,8 +33,6 @@ class AuthenticationEventHandler(
             authenticationId = authentication.id
         )
 
-        println(5)
         authenticationHistoryPort.save(history, authentication, student, studentUser)
-        println(6)
     }
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/handler/AuthenticationEventHandler.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/handler/AuthenticationEventHandler.kt
@@ -1,0 +1,37 @@
+package team.msg.sms.domain.authentication.handler
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import team.msg.sms.domain.authentication.event.AuthenticationHistoryEvent
+import team.msg.sms.domain.authentication.model.AuthenticationHistory
+import team.msg.sms.domain.authentication.spi.AuthenticationHistoryPort
+import team.msg.sms.domain.student.service.StudentService
+import team.msg.sms.domain.user.service.UserService
+
+@Component
+class AuthenticationEventHandler(
+    private val authenticationHistoryPort: AuthenticationHistoryPort,
+    private val studentService: StudentService,
+    private val userService: UserService
+) {
+
+    /**
+     * authentication history event가 발행되면 히스토리를 저장하는 핸들러입니다.
+     * @param authentication history event
+     */
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    fun authenticationHistoryHandler(event: AuthenticationHistoryEvent) {
+        val authentication = event.authentication
+        val student = studentService.getStudentByUuid(authentication.studentId)
+        val studentUser = userService.getUserById(student.userId)
+        val history = AuthenticationHistory(
+            reason = event.reason,
+            activityStatus = authentication.activityStatus,
+            teacherId = event.teacherId,
+            authenticationId = authentication.id
+        )
+
+        authenticationHistoryPort.save(history, authentication, student, studentUser)
+    }
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/handler/AuthenticationEventHandler.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/handler/AuthenticationEventHandler.kt
@@ -22,9 +22,13 @@ class AuthenticationEventHandler(
      */
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     fun authenticationHistoryHandler(event: AuthenticationHistoryEvent) {
+        println(1)
         val authentication = event.authentication
-        val student = studentService.getStudentByUuid(authentication.studentId)
+        println(2)
+        val student = studentService.getStudentByUserId(authentication.studentId)
+        println(3)
         val studentUser = userService.getUserById(student.userId)
+        println(4)
         val history = AuthenticationHistory(
             reason = event.reason,
             activityStatus = authentication.activityStatus,
@@ -32,6 +36,8 @@ class AuthenticationEventHandler(
             authenticationId = authentication.id
         )
 
+        println(5)
         authenticationHistoryPort.save(history, authentication, student, studentUser)
+        println(6)
     }
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/model/Authentication.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/model/Authentication.kt
@@ -1,0 +1,15 @@
+package team.msg.sms.domain.authentication.model
+
+import team.msg.sms.common.annotation.Aggregate
+import java.util.*
+
+@Aggregate
+class Authentication (
+    val id: UUID,
+    val title: String,
+    val content: String,
+    val activityImages: List<String> = mutableListOf(),
+    val score: Int = 0,
+    val activityStatus: ActivityStatus = ActivityStatus.PENDING,
+    val studentId: UUID
+)

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/model/AuthenticationHistory.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/model/AuthenticationHistory.kt
@@ -6,11 +6,10 @@ import java.util.*
 
 @Aggregate
 class AuthenticationHistory (
-    val id: Long,
+    val id: Long = 0,
     val reason: String,
-    val activityImages: List<String> = mutableListOf(),
-    val activityStatus: ActivityStatus = ActivityStatus.PENDING,
+    val activityStatus: ActivityStatus,
     val teacherId: UUID? = null,
     val authenticationId: UUID,
-    val createdAt: LocalDate
+    val createdAt: LocalDate = LocalDate.now()
 )

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/AuthenticationService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/AuthenticationService.kt
@@ -1,0 +1,5 @@
+package team.msg.sms.domain.authentication.service
+
+class AuthenticationService(
+    commandAuthenticationService: CommandAuthenticationService
+) : CommandAuthenticationService by commandAuthenticationService

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/AuthenticationService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/AuthenticationService.kt
@@ -1,5 +1,8 @@
 package team.msg.sms.domain.authentication.service
 
+import team.msg.sms.common.annotation.Service
+
+@Service
 class AuthenticationService(
     commandAuthenticationService: CommandAuthenticationService
 ) : CommandAuthenticationService by commandAuthenticationService

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/CommandAuthenticationService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/CommandAuthenticationService.kt
@@ -1,0 +1,13 @@
+package team.msg.sms.domain.authentication.service
+
+import team.msg.sms.domain.authentication.model.Authentication
+import team.msg.sms.domain.student.model.Student
+import team.msg.sms.domain.user.model.User
+
+interface CommandAuthenticationService {
+    fun save(
+        authentication: Authentication,
+        student: Student,
+        user: User
+    ): Authentication
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/CommandAuthenticationServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/CommandAuthenticationServiceImpl.kt
@@ -1,0 +1,19 @@
+package team.msg.sms.domain.authentication.service.impl
+
+import team.msg.sms.common.annotation.Service
+import team.msg.sms.domain.authentication.model.Authentication
+import team.msg.sms.domain.authentication.service.CommandAuthenticationService
+import team.msg.sms.domain.authentication.spi.AuthenticationPort
+import team.msg.sms.domain.student.model.Student
+import team.msg.sms.domain.user.model.User
+
+@Service
+class CommandAuthenticationServiceImpl(
+    private val authenticationPort: AuthenticationPort
+) : CommandAuthenticationService {
+    override fun save(
+        authentication: Authentication,
+        student: Student,
+        user: User
+    ) = authenticationPort.save(authentication, student, user)
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/AuthenticationHistoryPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/AuthenticationHistoryPort.kt
@@ -1,0 +1,3 @@
+package team.msg.sms.domain.authentication.spi
+
+interface AuthenticationHistoryPort : CommandAuthenticationHistoryPort

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/AuthenticationPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/AuthenticationPort.kt
@@ -1,0 +1,3 @@
+package team.msg.sms.domain.authentication.spi
+
+interface AuthenticationPort : CommandAuthenticationPort

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/CommandAuthenticationHistoryPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/CommandAuthenticationHistoryPort.kt
@@ -1,0 +1,7 @@
+package team.msg.sms.domain.authentication.spi
+
+import team.msg.sms.domain.authentication.model.AuthenticationHistory
+
+interface CommandAuthenticationHistoryPort {
+    fun save(authenticationHistory: AuthenticationHistory): AuthenticationHistory
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/CommandAuthenticationHistoryPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/CommandAuthenticationHistoryPort.kt
@@ -1,7 +1,15 @@
 package team.msg.sms.domain.authentication.spi
 
+import team.msg.sms.domain.authentication.model.Authentication
 import team.msg.sms.domain.authentication.model.AuthenticationHistory
+import team.msg.sms.domain.student.model.Student
+import team.msg.sms.domain.user.model.User
 
 interface CommandAuthenticationHistoryPort {
-    fun save(authenticationHistory: AuthenticationHistory): AuthenticationHistory
+    fun save(
+        authenticationHistory: AuthenticationHistory,
+        authentication: Authentication,
+        student: Student,
+        user: User
+    ): AuthenticationHistory
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/CommandAuthenticationPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/CommandAuthenticationPort.kt
@@ -1,7 +1,13 @@
 package team.msg.sms.domain.authentication.spi
 
 import team.msg.sms.domain.authentication.model.Authentication
+import team.msg.sms.domain.student.model.Student
+import team.msg.sms.domain.user.model.User
 
 interface CommandAuthenticationPort {
-    fun save(authentication: Authentication): Authentication
+    fun save(
+        authentication: Authentication,
+        student: Student,
+        user: User
+    ): Authentication
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/CommandAuthenticationPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/CommandAuthenticationPort.kt
@@ -1,0 +1,7 @@
+package team.msg.sms.domain.authentication.spi
+
+import team.msg.sms.domain.authentication.model.Authentication
+
+interface CommandAuthenticationPort {
+    fun save(authentication: Authentication): Authentication
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/CreateAuthenticationUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/CreateAuthenticationUseCase.kt
@@ -1,0 +1,44 @@
+package team.msg.sms.domain.authentication.usecase
+
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.transaction.annotation.Transactional
+import team.msg.sms.common.annotation.UseCase
+import team.msg.sms.domain.authentication.dto.req.CreateAuthenticationRequestData
+import team.msg.sms.domain.authentication.dto.res.CreateAuthenticationResponseData
+import team.msg.sms.domain.authentication.event.AuthenticationHistoryEvent
+import team.msg.sms.domain.authentication.model.Authentication
+import team.msg.sms.domain.authentication.service.AuthenticationService
+import team.msg.sms.domain.student.service.StudentService
+import team.msg.sms.domain.user.service.UserService
+import java.util.*
+
+@UseCase
+class CreateAuthenticationUseCase(
+    private val studentService: StudentService,
+    private val userService: UserService,
+    private val authenticationService: AuthenticationService,
+    private val applicationEventPublisher: ApplicationEventPublisher
+) {
+    @Transactional(rollbackFor = [Exception::class])
+    fun execute(createData: CreateAuthenticationRequestData): CreateAuthenticationResponseData {
+        val user = userService.getCurrentUser()
+        val student = studentService.getStudentByUser(user)
+
+        val authentication = Authentication(
+            id = UUID.randomUUID(),
+            title = createData.title,
+            content = createData.content,
+            activityImages = createData.activityImages,
+            studentId = student.id
+        ).let { authenticationService.save(it, student, user) }
+
+        AuthenticationHistoryEvent(
+            authentication = authentication,
+            reason = "활동이 저장되었습니다."
+        ).let { applicationEventPublisher.publishEvent(it) }
+
+        return CreateAuthenticationResponseData(
+            id = authentication.id
+        )
+    }
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/service/GetStudentService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/service/GetStudentService.kt
@@ -18,6 +18,8 @@ interface GetStudentService {
 
     fun getStudentUserInfoByUuid(uuid: String): Student.StudentWithUserInfo
 
+    fun getStudentById(uuid: UUID): Student
+
     fun getStudentByUserId(uuid: UUID): Student
 
     fun getStudentByUser(user: User): Student

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/service/GetStudentService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/service/GetStudentService.kt
@@ -18,7 +18,7 @@ interface GetStudentService {
 
     fun getStudentUserInfoByUuid(uuid: String): Student.StudentWithUserInfo
 
-    fun getStudentByUuid(uuid: UUID): Student
+    fun getStudentByUserId(uuid: UUID): Student
 
     fun getStudentByUser(user: User): Student
 

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/service/impl/GetStudentServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/service/impl/GetStudentServiceImpl.kt
@@ -45,11 +45,11 @@ class GetStudentServiceImpl(
         }
     }
 
-    override fun getStudentByUuid(uuid: UUID): Student =
+    override fun getStudentByUserId(uuid: UUID): Student =
         studentPort.queryStudentByUserId(uuid)
 
     override fun getStudentUserInfoByUuid(uuid: String): Student.StudentWithUserInfo =
-        studentPort.queryStudentById(UUID.fromString(uuid)) ?: throw StudentNotFoundException
+        studentPort.queryStudentWithUserInfoById(UUID.fromString(uuid)) ?: throw StudentNotFoundException
 
     override fun getStudentByUser(user: User): Student =
         studentPort.queryStudentByUser(user)

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/service/impl/GetStudentServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/service/impl/GetStudentServiceImpl.kt
@@ -51,6 +51,9 @@ class GetStudentServiceImpl(
     override fun getStudentUserInfoByUuid(uuid: String): Student.StudentWithUserInfo =
         studentPort.queryStudentWithUserInfoById(UUID.fromString(uuid)) ?: throw StudentNotFoundException
 
+    override fun getStudentById(uuid: UUID): Student =
+        studentPort.queryStudentById(uuid) ?: throw StudentNotFoundException
+
     override fun getStudentByUser(user: User): Student =
         studentPort.queryStudentByUser(user)
 

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/spi/QueryStudentPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/spi/QueryStudentPort.kt
@@ -6,6 +6,7 @@ import java.util.UUID
 
 interface QueryStudentPort {
     fun queryStudentWithUserInfoById(uuid: UUID): Student.StudentWithUserInfo?
+    fun queryStudentById(uuid: UUID): Student?
     fun queryStudentsWithPage(page: Int, size: Int): Student.StudentWithPageInfo
     fun queryStudentByUserId(userId: UUID): Student
     fun queryStudentUserInfoByUserId(userId: UUID): Student.StudentWithUserInfo?

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/spi/QueryStudentPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/spi/QueryStudentPort.kt
@@ -5,7 +5,7 @@ import team.msg.sms.domain.user.model.User
 import java.util.UUID
 
 interface QueryStudentPort {
-    fun queryStudentById(uuid: UUID): Student.StudentWithUserInfo?
+    fun queryStudentWithUserInfoById(uuid: UUID): Student.StudentWithUserInfo?
     fun queryStudentsWithPage(page: Int, size: Int): Student.StudentWithPageInfo
     fun queryStudentByUserId(userId: UUID): Student
     fun queryStudentUserInfoByUserId(userId: UUID): Student.StudentWithUserInfo?

--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
@@ -69,6 +69,8 @@ class SecurityConfig(
             .antMatchers(HttpMethod.POST, "/teacher/principal").hasAuthority(TEACHER)
             .antMatchers(HttpMethod.POST, "/teacher/deputy-principal").hasAuthority(TEACHER)
 
+            .antMatchers(HttpMethod.GET,"/authentication").hasAuthority(STUDENT)
+
             .antMatchers(HttpMethod.POST, "/file").authenticated()
             .antMatchers(HttpMethod.POST, "/file/image").authenticated()
 

--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
@@ -69,7 +69,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.POST, "/teacher/principal").hasAuthority(TEACHER)
             .antMatchers(HttpMethod.POST, "/teacher/deputy-principal").hasAuthority(TEACHER)
 
-            .antMatchers(HttpMethod.GET,"/authentication").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.POST,"/authentication").hasAuthority(STUDENT)
 
             .antMatchers(HttpMethod.POST, "/file").authenticated()
             .antMatchers(HttpMethod.POST, "/file/image").authenticated()

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/AuthenticationHistoryPersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/AuthenticationHistoryPersistenceAdapter.kt
@@ -1,0 +1,26 @@
+package team.msg.sms.persistence.authentication
+
+import org.springframework.stereotype.Component
+import team.msg.sms.domain.authentication.model.Authentication
+import team.msg.sms.domain.authentication.model.AuthenticationHistory
+import team.msg.sms.domain.authentication.spi.AuthenticationHistoryPort
+import team.msg.sms.domain.student.model.Student
+import team.msg.sms.domain.user.model.User
+import team.msg.sms.persistence.authentication.mapper.toDomain
+import team.msg.sms.persistence.authentication.mapper.toEntity
+import team.msg.sms.persistence.authentication.repository.AuthenticationHistoryJpaRepository
+import team.msg.sms.persistence.student.mapper.toEntity
+import team.msg.sms.persistence.user.mapper.toEntity
+
+@Component
+class AuthenticationHistoryPersistenceAdapter(
+    private val authenticationHistoryJpaRepository: AuthenticationHistoryJpaRepository
+) : AuthenticationHistoryPort {
+    override fun save(
+        authenticationHistory: AuthenticationHistory,
+        authentication: Authentication,
+        student: Student,
+        user: User
+    ): AuthenticationHistory =
+        authenticationHistoryJpaRepository.save(authenticationHistory.toEntity(authentication.toEntity(student.toEntity(user.toEntity())))).toDomain()
+}

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/AuthenticationPersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/AuthenticationPersistenceAdapter.kt
@@ -1,0 +1,25 @@
+package team.msg.sms.persistence.authentication
+
+import org.springframework.stereotype.Component
+import team.msg.sms.domain.authentication.model.Authentication
+import team.msg.sms.domain.authentication.spi.AuthenticationPort
+import team.msg.sms.domain.student.model.Student
+import team.msg.sms.domain.user.model.User
+import team.msg.sms.persistence.authentication.mapper.toDomain
+import team.msg.sms.persistence.authentication.mapper.toEntity
+import team.msg.sms.persistence.authentication.repository.AuthenticationJpaRepository
+import team.msg.sms.persistence.student.mapper.toEntity
+import team.msg.sms.persistence.user.mapper.toEntity
+
+@Component
+class AuthenticationPersistenceAdapter(
+    private val authenticationJpaRepository: AuthenticationJpaRepository
+) : AuthenticationPort {
+    override fun save(
+        authentication: Authentication,
+        student: Student,
+        user: User
+    ): Authentication =
+        authenticationJpaRepository.save(authentication.toEntity(student.toEntity(user.toEntity()))).toDomain()
+
+}

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/mapper/AuthenticationHistoryMapper.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/mapper/AuthenticationHistoryMapper.kt
@@ -1,0 +1,25 @@
+package team.msg.sms.persistence.authentication.mapper
+
+import team.msg.sms.domain.authentication.model.AuthenticationHistory
+import team.msg.sms.persistence.authentication.entity.AuthenticationHistoryJpaEntity
+import team.msg.sms.persistence.authentication.entity.AuthenticationJpaEntity
+import team.msg.sms.persistence.teacher.entity.TeacherJpaEntity
+
+fun AuthenticationHistory.toEntity(
+    authentication: AuthenticationJpaEntity,
+    teacher: TeacherJpaEntity? = null
+) = AuthenticationHistoryJpaEntity(
+    id = id,
+    reason = reason,
+    activityStatus = activityStatus,
+    teacher = teacher,
+    authentication = authentication
+)
+
+fun AuthenticationHistoryJpaEntity.toDomain() = AuthenticationHistory(
+    id = id,
+    reason = reason,
+    activityStatus = activityStatus,
+    teacherId = teacher?.id,
+    authenticationId = authentication.id
+)

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/mapper/AuthenticationMapper.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/mapper/AuthenticationMapper.kt
@@ -1,0 +1,25 @@
+package team.msg.sms.persistence.authentication.mapper
+
+import team.msg.sms.domain.authentication.model.Authentication
+import team.msg.sms.persistence.authentication.entity.AuthenticationJpaEntity
+import team.msg.sms.persistence.student.entity.StudentJpaEntity
+
+fun Authentication.toEntity(student: StudentJpaEntity) = AuthenticationJpaEntity(
+    id = id,
+    title = title,
+    content = content,
+    activityImages = activityImages,
+    score = score,
+    activityStatus = activityStatus,
+    student = student,
+)
+
+fun AuthenticationJpaEntity.toDomain() = Authentication(
+    id = id,
+    title = title,
+    content = content,
+    activityImages = activityImages,
+    score = score,
+    activityStatus = activityStatus,
+    studentId = student.id
+)

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/repository/AuthenticationHistoryJpaRepository.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/repository/AuthenticationHistoryJpaRepository.kt
@@ -2,6 +2,7 @@ package team.msg.sms.persistence.authentication.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import team.msg.sms.persistence.authentication.entity.AuthenticationHistoryJpaEntity
 
 @Repository
-interface AuthenticationHistoryJpaRepository : JpaRepository<AuthenticationHistoryJpaRepository, Long>
+interface AuthenticationHistoryJpaRepository : JpaRepository<AuthenticationHistoryJpaEntity, Long>

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/repository/AuthenticationHistoryJpaRepository.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/repository/AuthenticationHistoryJpaRepository.kt
@@ -1,5 +1,7 @@
 package team.msg.sms.persistence.authentication.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 
+@Repository
 interface AuthenticationHistoryJpaRepository : JpaRepository<AuthenticationHistoryJpaRepository, Long>

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/repository/AuthenticationJpaRepository.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/repository/AuthenticationJpaRepository.kt
@@ -1,7 +1,9 @@
 package team.msg.sms.persistence.authentication.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 import team.msg.sms.persistence.authentication.entity.AuthenticationJpaEntity
 import java.util.*
 
+@Repository
 interface AuthenticationJpaRepository : JpaRepository<AuthenticationJpaEntity, UUID>

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/student/StudentPersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/student/StudentPersistenceAdapter.kt
@@ -29,7 +29,7 @@ class StudentPersistenceAdapter(
     override fun deleteById(studentId: UUID) =
         studentJpaRepository.deleteById(studentId)
 
-    override fun queryStudentById(uuid: UUID): Student.StudentWithUserInfo? =
+    override fun queryStudentWithUserInfoById(uuid: UUID): Student.StudentWithUserInfo? =
         studentJpaRepository.findByIdOrNull(uuid)?.toDomainWithUserInfo()
 
     override fun existsStudentById(uuid: UUID): Boolean =

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/student/StudentPersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/student/StudentPersistenceAdapter.kt
@@ -32,6 +32,9 @@ class StudentPersistenceAdapter(
     override fun queryStudentWithUserInfoById(uuid: UUID): Student.StudentWithUserInfo? =
         studentJpaRepository.findByIdOrNull(uuid)?.toDomainWithUserInfo()
 
+    override fun queryStudentById(uuid: UUID): Student? =
+        studentJpaRepository.findByIdOrNull(uuid)?.toDomain()
+
     override fun existsStudentById(uuid: UUID): Boolean =
         studentJpaRepository.existsById(uuid)
 

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/AuthenticationWebAdapter.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/AuthenticationWebAdapter.kt
@@ -1,0 +1,28 @@
+package team.msg.sms.domain.authentication
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import team.msg.sms.domain.authentication.dto.res.CreateAuthenticationResponseData
+import team.msg.sms.domain.authentication.req.CreateAuthenticationWebRequest
+import team.msg.sms.domain.authentication.res.CreateAuthenticationWebResponse
+import team.msg.sms.domain.authentication.usecase.CreateAuthenticationUseCase
+import javax.validation.Valid
+
+@RestController
+@RequestMapping("/authentication")
+class AuthenticationWebAdapter(
+    private val createAuthenticationUseCase: CreateAuthenticationUseCase
+) {
+    @PostMapping
+    fun createAuthentication(@Valid @RequestBody request: CreateAuthenticationWebRequest): ResponseEntity<CreateAuthenticationWebResponse> =
+        createAuthenticationUseCase.execute(request.toData())
+            .let { ResponseEntity.status(HttpStatus.CREATED).body(it.toResponse()) }
+
+    private fun CreateAuthenticationResponseData.toResponse() = CreateAuthenticationWebResponse(
+        id = id
+    )
+}

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/req/CreateAuthenticationWebRequest.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/req/CreateAuthenticationWebRequest.kt
@@ -1,0 +1,24 @@
+package team.msg.sms.domain.authentication.req
+
+import team.msg.sms.domain.authentication.dto.req.CreateAuthenticationRequestData
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Size
+
+data class CreateAuthenticationWebRequest (
+    @field:NotBlank
+    val title: String,
+
+    @field:NotBlank
+    val content: String,
+
+    @field:NotNull
+    @field:Size(max = 4)
+    val activityImages: List<String>
+) {
+    fun toData() = CreateAuthenticationRequestData(
+        title = title,
+        content = content,
+        activityImages = activityImages
+    )
+}

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/res/CreateAuthenticationWebResponse.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/res/CreateAuthenticationWebResponse.kt
@@ -1,0 +1,7 @@
+package team.msg.sms.domain.authentication.res
+
+import java.util.UUID
+
+data class CreateAuthenticationWebResponse (
+    val id: UUID
+)


### PR DESCRIPTION
## 💡 개요
인증제 활동 생성 api를 작성했습니다.

## 📃 작업내용
- 인증제 활동을 생성하는 api를 작성했습니다.
- 이벤트 퍼블리셔를 사용해 히스토리를 저장하는 로직을 분리했습니다.

## 🔀 변경사항
- student 객체를 찾는 함수 중 중복되는 함수명이 있어 변경해주었습니다.

## 🍴 사용방법
- 추후 인증제 내용이 변경되는 일이 생기면 이벤트를 발행하면 됩니다.
