### PR TITLE
인증제 활동 상세조회 api 를 작성했습니다.

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/dto/res/QueryAuthenticationDetailsResponseData.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/dto/res/QueryAuthenticationDetailsResponseData.kt
@@ -1,0 +1,15 @@
+package team.msg.sms.domain.authentication.dto.res
+
+import team.msg.sms.domain.authentication.model.ActivityStatus
+import java.time.LocalDate
+import java.util.UUID
+
+data class QueryAuthenticationDetailsResponseData (
+    val id: UUID,
+    val title: String,
+    val content: String,
+    val activityImages: List<String>,
+    val lastModifiedDate: LocalDate,
+    val score: Int,
+    val activityStatus: ActivityStatus
+)

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/exception/AuthenticationNotFoundException.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/exception/AuthenticationNotFoundException.kt
@@ -1,0 +1,8 @@
+package team.msg.sms.domain.authentication.exception
+
+import team.msg.sms.common.error.SmsException
+import team.msg.sms.domain.authentication.exception.error.AuthenticationErrorCode
+
+object AuthenticationNotFoundException : SmsException(
+    AuthenticationErrorCode.AUTHENTICATION_NOT_FOUND
+)

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/exception/error/AuthenticationErrorCode.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/exception/error/AuthenticationErrorCode.kt
@@ -1,0 +1,17 @@
+package team.msg.sms.domain.authentication.exception.error
+
+import team.msg.sms.common.error.ErrorProperty
+import team.msg.sms.common.error.ErrorStatus
+
+enum class AuthenticationErrorCode(
+    private val status: Int,
+    private val message: String
+) : ErrorProperty {
+    AUTHENTICATION_NOT_FOUND(ErrorStatus.NOT_FOUND, "인증제 활동을 찾을 수 없습니다.")
+    ;
+
+    override fun status(): Int = status
+
+    override fun message(): String = message
+
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/model/AuthenticationHistory.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/model/AuthenticationHistory.kt
@@ -1,7 +1,7 @@
 package team.msg.sms.domain.authentication.model
 
 import team.msg.sms.common.annotation.Aggregate
-import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.*
 
 @Aggregate
@@ -11,5 +11,5 @@ class AuthenticationHistory (
     val activityStatus: ActivityStatus,
     val teacherId: UUID? = null,
     val authenticationId: UUID,
-    val createdAt: LocalDate = LocalDate.now()
+    val createdAt: LocalDateTime = LocalDateTime.now()
 )

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/AuthenticationHistoryService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/AuthenticationHistoryService.kt
@@ -1,0 +1,8 @@
+package team.msg.sms.domain.authentication.service
+
+import team.msg.sms.common.annotation.Service
+
+@Service
+class AuthenticationHistoryService(
+    getAuthenticationHistoryService: GetAuthenticationHistoryService
+) : GetAuthenticationHistoryService by getAuthenticationHistoryService

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/AuthenticationService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/AuthenticationService.kt
@@ -4,5 +4,7 @@ import team.msg.sms.common.annotation.Service
 
 @Service
 class AuthenticationService(
-    commandAuthenticationService: CommandAuthenticationService
-) : CommandAuthenticationService by commandAuthenticationService
+    commandAuthenticationService: CommandAuthenticationService,
+    getAuthenticationService: GetAuthenticationService
+) : CommandAuthenticationService by commandAuthenticationService,
+    GetAuthenticationService by getAuthenticationService

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/GetAuthenticationHistoryService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/GetAuthenticationHistoryService.kt
@@ -2,8 +2,13 @@ package team.msg.sms.domain.authentication.service
 
 import team.msg.sms.domain.authentication.model.Authentication
 import team.msg.sms.domain.authentication.model.AuthenticationHistory
-import java.util.UUID
+import team.msg.sms.domain.student.model.Student
+import team.msg.sms.domain.user.model.User
 
 interface GetAuthenticationHistoryService {
-    fun getLatestAuthenticationHistory(authentication: Authentication): AuthenticationHistory
+    fun getLatestAuthenticationHistory(
+        authentication: Authentication,
+        student: Student,
+        user: User
+    ): AuthenticationHistory
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/GetAuthenticationHistoryService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/GetAuthenticationHistoryService.kt
@@ -1,0 +1,9 @@
+package team.msg.sms.domain.authentication.service
+
+import team.msg.sms.domain.authentication.model.Authentication
+import team.msg.sms.domain.authentication.model.AuthenticationHistory
+import java.util.UUID
+
+interface GetAuthenticationHistoryService {
+    fun getLatestAuthenticationHistory(authentication: Authentication): AuthenticationHistory
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/GetAuthenticationService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/GetAuthenticationService.kt
@@ -1,0 +1,8 @@
+package team.msg.sms.domain.authentication.service
+
+import team.msg.sms.domain.authentication.model.Authentication
+import java.util.UUID
+
+interface GetAuthenticationService {
+    fun getAuthenticationByUuid(uuid: UUID): Authentication
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/GetAuthenticationHistoryServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/GetAuthenticationHistoryServiceImpl.kt
@@ -1,0 +1,16 @@
+package team.msg.sms.domain.authentication.service.impl
+
+import team.msg.sms.common.annotation.Service
+import team.msg.sms.domain.authentication.model.Authentication
+import team.msg.sms.domain.authentication.model.AuthenticationHistory
+import team.msg.sms.domain.authentication.service.GetAuthenticationHistoryService
+import team.msg.sms.domain.authentication.spi.QueryAuthenticationHistoryPort
+
+@Service
+class GetAuthenticationHistoryServiceImpl(
+    private val queryAuthenticationHistoryPort: QueryAuthenticationHistoryPort
+) : GetAuthenticationHistoryService{
+    override fun getLatestAuthenticationHistory(authentication: Authentication): AuthenticationHistory =
+        queryAuthenticationHistoryPort.queryLatestAuthenticationHistory(authentication)
+
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/GetAuthenticationHistoryServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/GetAuthenticationHistoryServiceImpl.kt
@@ -5,12 +5,18 @@ import team.msg.sms.domain.authentication.model.Authentication
 import team.msg.sms.domain.authentication.model.AuthenticationHistory
 import team.msg.sms.domain.authentication.service.GetAuthenticationHistoryService
 import team.msg.sms.domain.authentication.spi.QueryAuthenticationHistoryPort
+import team.msg.sms.domain.student.model.Student
+import team.msg.sms.domain.user.model.User
 
 @Service
 class GetAuthenticationHistoryServiceImpl(
     private val queryAuthenticationHistoryPort: QueryAuthenticationHistoryPort
 ) : GetAuthenticationHistoryService{
-    override fun getLatestAuthenticationHistory(authentication: Authentication): AuthenticationHistory =
-        queryAuthenticationHistoryPort.queryLatestAuthenticationHistory(authentication)
+    override fun getLatestAuthenticationHistory(
+        authentication: Authentication,
+        student: Student,
+        user: User
+    ): AuthenticationHistory =
+        queryAuthenticationHistoryPort.queryLatestAuthenticationHistory(authentication, student, user)
 
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/GetAuthenticationServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/GetAuthenticationServiceImpl.kt
@@ -1,6 +1,7 @@
 package team.msg.sms.domain.authentication.service.impl
 
 import team.msg.sms.common.annotation.Service
+import team.msg.sms.domain.authentication.exception.AuthenticationNotFoundException
 import team.msg.sms.domain.authentication.model.Authentication
 import team.msg.sms.domain.authentication.service.GetAuthenticationService
 import team.msg.sms.domain.authentication.spi.QueryAuthenticationPort
@@ -11,5 +12,5 @@ class GetAuthenticationServiceImpl(
     private val queryAuthenticationPort: QueryAuthenticationPort
 ) : GetAuthenticationService {
     override fun getAuthenticationByUuid(uuid: UUID): Authentication =
-        queryAuthenticationPort.queryAuthenticationByUuid(uuid)
+        queryAuthenticationPort.queryAuthenticationByUuid(uuid) ?: throw AuthenticationNotFoundException
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/GetAuthenticationServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/GetAuthenticationServiceImpl.kt
@@ -1,0 +1,15 @@
+package team.msg.sms.domain.authentication.service.impl
+
+import team.msg.sms.common.annotation.Service
+import team.msg.sms.domain.authentication.model.Authentication
+import team.msg.sms.domain.authentication.service.GetAuthenticationService
+import team.msg.sms.domain.authentication.spi.QueryAuthenticationPort
+import java.util.UUID
+
+@Service
+class GetAuthenticationServiceImpl(
+    private val queryAuthenticationPort: QueryAuthenticationPort
+) : GetAuthenticationService {
+    override fun getAuthenticationByUuid(uuid: UUID): Authentication =
+        queryAuthenticationPort.queryAuthenticationByUuid(uuid)
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/AuthenticationHistoryPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/AuthenticationHistoryPort.kt
@@ -1,3 +1,3 @@
 package team.msg.sms.domain.authentication.spi
 
-interface AuthenticationHistoryPort : CommandAuthenticationHistoryPort
+interface AuthenticationHistoryPort : CommandAuthenticationHistoryPort, QueryAuthenticationHistoryPort

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/AuthenticationPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/AuthenticationPort.kt
@@ -1,3 +1,3 @@
 package team.msg.sms.domain.authentication.spi
 
-interface AuthenticationPort : CommandAuthenticationPort
+interface AuthenticationPort : CommandAuthenticationPort, QueryAuthenticationPort

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/QueryAuthenticationHistoryPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/QueryAuthenticationHistoryPort.kt
@@ -2,7 +2,13 @@ package team.msg.sms.domain.authentication.spi
 
 import team.msg.sms.domain.authentication.model.Authentication
 import team.msg.sms.domain.authentication.model.AuthenticationHistory
+import team.msg.sms.domain.student.model.Student
+import team.msg.sms.domain.user.model.User
 
 interface QueryAuthenticationHistoryPort {
-    fun queryLatestAuthenticationHistory(authentication: Authentication): AuthenticationHistory
+    fun queryLatestAuthenticationHistory(
+        authentication: Authentication,
+        student: Student,
+        user: User
+    ): AuthenticationHistory
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/QueryAuthenticationHistoryPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/QueryAuthenticationHistoryPort.kt
@@ -1,0 +1,8 @@
+package team.msg.sms.domain.authentication.spi
+
+import team.msg.sms.domain.authentication.model.Authentication
+import team.msg.sms.domain.authentication.model.AuthenticationHistory
+
+interface QueryAuthenticationHistoryPort {
+    fun queryLatestAuthenticationHistory(authentication: Authentication): AuthenticationHistory
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/QueryAuthenticationPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/QueryAuthenticationPort.kt
@@ -4,5 +4,5 @@ import team.msg.sms.domain.authentication.model.Authentication
 import java.util.UUID
 
 interface QueryAuthenticationPort {
-    fun queryAuthenticationByUuid(uuid: UUID): Authentication
+    fun queryAuthenticationByUuid(uuid: UUID): Authentication?
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/QueryAuthenticationPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/QueryAuthenticationPort.kt
@@ -1,0 +1,8 @@
+package team.msg.sms.domain.authentication.spi
+
+import team.msg.sms.domain.authentication.model.Authentication
+import java.util.UUID
+
+interface QueryAuthenticationPort {
+    fun queryAuthenticationByUuid(uuid: UUID): Authentication
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryAuthenticationDetailsUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryAuthenticationDetailsUseCase.kt
@@ -1,0 +1,28 @@
+package team.msg.sms.domain.authentication.usecase
+
+import team.msg.sms.common.annotation.UseCase
+import team.msg.sms.domain.authentication.dto.res.QueryAuthenticationDetailsResponseData
+import team.msg.sms.domain.authentication.service.GetAuthenticationHistoryService
+import team.msg.sms.domain.authentication.spi.QueryAuthenticationPort
+import java.util.*
+
+@UseCase
+class QueryAuthenticationDetailsUseCase(
+    private val getAuthenticationPort: QueryAuthenticationPort,
+    private val getAuthenticationHistoryService: GetAuthenticationHistoryService
+) {
+    fun execute(uuid: String): QueryAuthenticationDetailsResponseData {
+        val authentication = getAuthenticationPort.queryAuthenticationByUuid(UUID.fromString(uuid))
+        val history = getAuthenticationHistoryService.getLatestAuthenticationHistory(authentication)
+
+        return QueryAuthenticationDetailsResponseData(
+            id = authentication.id,
+            title = authentication.title,
+            content = authentication.title,
+            activityImages = authentication.activityImages,
+            lastModifiedDate = history.createdAt,
+            score = authentication.score,
+            activityStatus = authentication.activityStatus
+        )
+    }
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryAuthenticationDetailsUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryAuthenticationDetailsUseCase.kt
@@ -2,25 +2,31 @@ package team.msg.sms.domain.authentication.usecase
 
 import team.msg.sms.common.annotation.UseCase
 import team.msg.sms.domain.authentication.dto.res.QueryAuthenticationDetailsResponseData
-import team.msg.sms.domain.authentication.service.GetAuthenticationHistoryService
-import team.msg.sms.domain.authentication.spi.QueryAuthenticationPort
+import team.msg.sms.domain.authentication.service.AuthenticationHistoryService
+import team.msg.sms.domain.authentication.service.AuthenticationService
+import team.msg.sms.domain.student.service.StudentService
+import team.msg.sms.domain.user.service.UserService
 import java.util.*
 
 @UseCase
 class QueryAuthenticationDetailsUseCase(
-    private val getAuthenticationPort: QueryAuthenticationPort,
-    private val getAuthenticationHistoryService: GetAuthenticationHistoryService
+    private val authenticationService: AuthenticationService,
+    private val authenticationHistoryService: AuthenticationHistoryService,
+    private val studentService: StudentService,
+    private val userService: UserService
 ) {
     fun execute(uuid: String): QueryAuthenticationDetailsResponseData {
-        val authentication = getAuthenticationPort.queryAuthenticationByUuid(UUID.fromString(uuid))
-        val history = getAuthenticationHistoryService.getLatestAuthenticationHistory(authentication)
+        val authentication = authenticationService.getAuthenticationByUuid(UUID.fromString(uuid))
+        val student = studentService.getStudentById(authentication.studentId)
+        val user = userService.getUserById(student.userId)
+        val history = authenticationHistoryService.getLatestAuthenticationHistory(authentication, student, user)
 
         return QueryAuthenticationDetailsResponseData(
             id = authentication.id,
             title = authentication.title,
             content = authentication.title,
             activityImages = authentication.activityImages,
-            lastModifiedDate = history.createdAt,
+            lastModifiedDate = history.createdAt.toLocalDate(),
             score = authentication.score,
             activityStatus = authentication.activityStatus
         )

--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/config/JacksonConfiguration.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/config/JacksonConfiguration.kt
@@ -1,5 +1,6 @@
 package team.msg.sms.global.config
 
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -12,4 +13,5 @@ class JacksonConfiguration {
     fun jackson2ObjectMapperBuilder(): Jackson2ObjectMapperBuilder =
         Jackson2ObjectMapperBuilder()
             .serializers(LocalDateTimeSerializer(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")))
+            .serializers(LocalDateSerializer(DateTimeFormatter.ofPattern("yyyy-MM-d")))
 }

--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
@@ -70,6 +70,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.POST, "/teacher/deputy-principal").hasAuthority(TEACHER)
 
             .antMatchers(HttpMethod.POST,"/authentication").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.GET,"/authentication/{uuid}").hasAuthority(STUDENT)
 
             .antMatchers(HttpMethod.POST, "/file").authenticated()
             .antMatchers(HttpMethod.POST, "/file/image").authenticated()

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/AuthenticationHistoryPersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/AuthenticationHistoryPersistenceAdapter.kt
@@ -23,4 +23,11 @@ class AuthenticationHistoryPersistenceAdapter(
         user: User
     ): AuthenticationHistory =
         authenticationHistoryJpaRepository.save(authenticationHistory.toEntity(authentication.toEntity(student.toEntity(user.toEntity())))).toDomain()
+
+    override fun queryLatestAuthenticationHistory(
+        authentication: Authentication,
+        student: Student,
+        user: User
+    ): AuthenticationHistory =
+        authenticationHistoryJpaRepository.findByAuthenticationOrderByCreatedAtDesc(authentication.toEntity(student.toEntity(user.toEntity()))).toDomain()
 }

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/AuthenticationPersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/AuthenticationPersistenceAdapter.kt
@@ -1,5 +1,6 @@
 package team.msg.sms.persistence.authentication
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import team.msg.sms.domain.authentication.model.Authentication
 import team.msg.sms.domain.authentication.spi.AuthenticationPort
@@ -10,6 +11,7 @@ import team.msg.sms.persistence.authentication.mapper.toEntity
 import team.msg.sms.persistence.authentication.repository.AuthenticationJpaRepository
 import team.msg.sms.persistence.student.mapper.toEntity
 import team.msg.sms.persistence.user.mapper.toEntity
+import java.util.*
 
 @Component
 class AuthenticationPersistenceAdapter(
@@ -21,5 +23,8 @@ class AuthenticationPersistenceAdapter(
         user: User
     ): Authentication =
         authenticationJpaRepository.save(authentication.toEntity(student.toEntity(user.toEntity()))).toDomain()
+
+    override fun queryAuthenticationByUuid(uuid: UUID): Authentication? =
+        authenticationJpaRepository.findByIdOrNull(uuid)?.toDomain()
 
 }

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/entity/AuthenticationHistoryJpaEntity.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/entity/AuthenticationHistoryJpaEntity.kt
@@ -1,8 +1,10 @@
 package team.msg.sms.persistence.authentication.entity
 
+import org.springframework.data.annotation.CreatedDate
 import team.msg.sms.domain.authentication.model.ActivityStatus
 import team.msg.sms.persistence.BaseIdEntity
 import team.msg.sms.persistence.teacher.entity.TeacherJpaEntity
+import java.time.LocalDateTime
 import javax.persistence.*
 
 @Entity
@@ -22,5 +24,8 @@ class AuthenticationHistoryJpaEntity (
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "authentication_id")
-    val authentication: AuthenticationJpaEntity
+    val authentication: AuthenticationJpaEntity,
+
+    @CreatedDate
+    val createdAt: LocalDateTime
 ) : BaseIdEntity()

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/mapper/AuthenticationHistoryMapper.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/mapper/AuthenticationHistoryMapper.kt
@@ -13,7 +13,8 @@ fun AuthenticationHistory.toEntity(
     reason = reason,
     activityStatus = activityStatus,
     teacher = teacher,
-    authentication = authentication
+    authentication = authentication,
+    createdAt = createdAt
 )
 
 fun AuthenticationHistoryJpaEntity.toDomain() = AuthenticationHistory(
@@ -21,5 +22,6 @@ fun AuthenticationHistoryJpaEntity.toDomain() = AuthenticationHistory(
     reason = reason,
     activityStatus = activityStatus,
     teacherId = teacher?.id,
-    authenticationId = authentication.id
+    authenticationId = authentication.id,
+    createdAt = createdAt
 )

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/repository/AuthenticationHistoryJpaRepository.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/repository/AuthenticationHistoryJpaRepository.kt
@@ -3,6 +3,9 @@ package team.msg.sms.persistence.authentication.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import team.msg.sms.persistence.authentication.entity.AuthenticationHistoryJpaEntity
+import team.msg.sms.persistence.authentication.entity.AuthenticationJpaEntity
 
 @Repository
-interface AuthenticationHistoryJpaRepository : JpaRepository<AuthenticationHistoryJpaEntity, Long>
+interface AuthenticationHistoryJpaRepository : JpaRepository<AuthenticationHistoryJpaEntity, Long> {
+    fun findByAuthenticationOrderByCreatedAtDesc(authentication: AuthenticationJpaEntity): AuthenticationHistoryJpaEntity
+}

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/AuthenticationWebAdapter.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/AuthenticationWebAdapter.kt
@@ -2,27 +2,56 @@ package team.msg.sms.domain.authentication
 
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
+import team.msg.sms.common.exception.InvalidUuidException
 import team.msg.sms.domain.authentication.dto.res.CreateAuthenticationResponseData
+import team.msg.sms.domain.authentication.dto.res.QueryAuthenticationDetailsResponseData
 import team.msg.sms.domain.authentication.req.CreateAuthenticationWebRequest
 import team.msg.sms.domain.authentication.res.CreateAuthenticationWebResponse
+import team.msg.sms.domain.authentication.res.QueryAuthenticationDetailsWebResponse
 import team.msg.sms.domain.authentication.usecase.CreateAuthenticationUseCase
+import team.msg.sms.domain.authentication.usecase.QueryAuthenticationDetailsUseCase
+import java.util.*
 import javax.validation.Valid
 
 @RestController
 @RequestMapping("/authentication")
 class AuthenticationWebAdapter(
-    private val createAuthenticationUseCase: CreateAuthenticationUseCase
+    private val createAuthenticationUseCase: CreateAuthenticationUseCase,
+    private val queryAuthenticationDetailsUseCase: QueryAuthenticationDetailsUseCase
 ) {
     @PostMapping
     fun createAuthentication(@Valid @RequestBody request: CreateAuthenticationWebRequest): ResponseEntity<CreateAuthenticationWebResponse> =
         createAuthenticationUseCase.execute(request.toData())
             .let { ResponseEntity.status(HttpStatus.CREATED).body(it.toResponse()) }
 
+    @GetMapping("/{uuid}")
+    fun queryAuthenticationDetails(@PathVariable uuid: String): ResponseEntity<QueryAuthenticationDetailsWebResponse> {
+        if (!isValidUUID(uuid)) throw InvalidUuidException
+        return queryAuthenticationDetailsUseCase.execute(uuid)
+            .let { ResponseEntity.ok(it.toResponse()) }
+    }
+
     private fun CreateAuthenticationResponseData.toResponse() = CreateAuthenticationWebResponse(
         id = id
     )
+
+    private fun QueryAuthenticationDetailsResponseData.toResponse() = QueryAuthenticationDetailsWebResponse(
+        id = id,
+        title = title,
+        content = content,
+        activityImages = activityImages,
+        lastModifiedDate = lastModifiedDate,
+        score = score,
+        activityStatus = activityStatus
+    )
+
+    private fun isValidUUID(uuid: String): Boolean {
+        return try {
+            UUID.fromString(uuid)
+            true
+        } catch (ex: IllegalArgumentException) {
+            false
+        }
+    }
 }

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/res/QueryAuthenticationDetailsWebResponse.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/res/QueryAuthenticationDetailsWebResponse.kt
@@ -1,0 +1,15 @@
+package team.msg.sms.domain.authentication.res
+
+import team.msg.sms.domain.authentication.model.ActivityStatus
+import java.time.LocalDate
+import java.util.*
+
+data class QueryAuthenticationDetailsWebResponse(
+    val id: UUID,
+    val title: String,
+    val content: String,
+    val activityImages: List<String>,
+    val lastModifiedDate: LocalDate,
+    val score: Int,
+    val activityStatus: ActivityStatus
+)


### PR DESCRIPTION
## 💡 개요
인증제 활동 상세조회 api 를 작성했습니다.

## 📃 작업내용
- 인증제 활동 상세조회 api
- 최신 히스토리를 가져와 생성 날짜를 조회합니다.
- LocalDate 데이터포메터를 작성했습니다.

## 🔀 변경사항
- 활동 히스토리에 생성일을 나타내는 createdAt을 추가했습니다.