### PR TITLE
Gauth 버전을 2.0.0 에서 3.0.0으로 변경했습니다.

### DIFF
--- a/buildSrc/src/main/kotlin/DependencyVersions.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersions.kt
@@ -6,7 +6,7 @@ object DependencyVersions {
     const val MOCKITO_VERSION = "4.0.0"
     const val AWS_VERSION = "2.2.6.RELEASE"
     const val SERVLET_VERSION = "4.0.1"
-    const val GAUTH_VERSION = "2.0.0"
+    const val GAUTH_VERSION = "3.0.0"
     const val SPRING_TRANSACTION = "5.3.22"
     const val QUERYDSL = "5.0.0"
     const val MARIA_VERSION = "2.1.2"


### PR DESCRIPTION
## 💡 개요
GAuth 버전을 2.0.0에서 3.0.0으로 변경했습니다.

## 🔀 변경사항
Gauth 3.0.0

## 🎸 기타
hotfix이므로 master 브랜치에 merge됩니다!
