### PR TITLE
update :: gauth 버전 2 -> 3

### DIFF
--- a/buildSrc/src/main/kotlin/DependencyVersions.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersions.kt
@@ -6,7 +6,7 @@ object DependencyVersions {
     const val MOCKITO_VERSION = "4.0.0"
     const val AWS_VERSION = "2.2.6.RELEASE"
     const val SERVLET_VERSION = "4.0.1"
-    const val GAUTH_VERSION = "2.0.0"
+    const val GAUTH_VERSION = "3.0.0"
     const val SPRING_TRANSACTION = "5.3.22"
     const val QUERYDSL = "5.0.0"
     const val MARIA_VERSION = "2.1.2"


### PR DESCRIPTION
## 💡 개요

개발 서버 gauth 버전을 2.0.0에서 3.0.0으로 변경했습니다. 

## 📃 작업내용

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
