### PR TITLE
로그인 시 GAuth 학번과 다르면 업데이트

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/auth/usecase/SignInUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/auth/usecase/SignInUseCase.kt
@@ -73,6 +73,6 @@ class SignInUseCase(
 }
 
 private fun getStuNumValid(role: Role, gAuthUserInfo: GAuthUserInfo) =
-    if (role.name != "ROLE_TEACHER") "${gAuthUserInfo.grade}${gAuthUserInfo.classNum}${gAuthUserInfo.getNumber()}" else ""
+    if (role.name == "ROLE_STUDENT") "${gAuthUserInfo.grade}${gAuthUserInfo.classNum}${gAuthUserInfo.getNumber()}" else ""
 
 private fun GAuthUserInfo.getNumber() = String.format("%02d", this.num)

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/auth/usecase/SignInUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/auth/usecase/SignInUseCase.kt
@@ -33,15 +33,21 @@ class SignInUseCase(
             val role = userService.getRoleByGAuthInfo(gAuthUserInfo.email, gAuthUserInfo.role)
 
             val isExistsUser = userService.checkUserExistByEmail(gAuthUserInfo.email)
+
+            val stuNum = getStuNumValid(role, gAuthUserInfo)
+
             val user = userService.createUserWhenNotExistUser(
                 isExistsUser,
                 User(
                     name = gAuthUserInfo.name,
                     email = gAuthUserInfo.email,
-                    stuNum = getStuNumValid(role, gAuthUserInfo),
+                    stuNum = stuNum,
                     roles = mutableListOf(role)
                 )
             )
+
+            if(user.stuNum != stuNum)
+                userService.updateStuNum(user, stuNum)
 
             val (accessToken, accessTokenExp, refreshToken, refreshTokenExp) = jwtPort.receiveToken(user.id, role)
 

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/user/service/CommandUserService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/user/service/CommandUserService.kt
@@ -6,6 +6,7 @@ import java.util.UUID
 
 interface CommandUserService {
     fun createUserWhenNotExistUser(existUser: Boolean, user: User): User
+    fun updateStuNum(user: User, stuNum: String): User
     fun saveRoles(user: User, role: List<Role>): User
     fun deleteByUuid(userId: UUID)
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/user/service/impl/CommandUserServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/user/service/impl/CommandUserServiceImpl.kt
@@ -16,9 +16,16 @@ class CommandUserServiceImpl(
         return if(existUser) {
             userPort.queryUserByEmail(user.email) ?: throw UserNotFoundException
         } else {
-            userPort.saveUser(user)!!
+            userPort.saveUser(user)
         }
     }
+
+    override fun updateStuNum(user: User, stuNum: String) =
+        userPort.saveUser(
+            user.copy(
+                stuNum = stuNum
+            )
+        )
 
     override fun saveRoles(user: User, role: List<Role>): User {
         user.roles.addAll(role)


### PR DESCRIPTION
## 💡 개요

로그인 시 GAuth 학번과 다르면 업데이트

## 📃 작업내용

sms에 로그인 했을 때 GAuth의 학번과 서버에 저장된 학번이 다르면 정보를 업데이트할 수 있도록 로직을 추가했습니다.

## 🔀 변경사항

졸업생도 stuNum이 빈 문자열로 저장되도록 변경했습니다.

