### PR TITLE
🔁 링크 최소 최대 만료기간 지정

### DIFF
--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/student/dto/req/CreateStudentLinkWebRequest.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/student/dto/req/CreateStudentLinkWebRequest.kt
@@ -1,9 +1,15 @@
 package team.msg.sms.domain.student.dto.req
 
 import java.util.UUID
+import javax.validation.constraints.*
 
 data class CreateStudentLinkWebRequest (
+	@field:NotBlank
 	val studentId: UUID,
+
+	@field:Min(1)
+	@field:Max(30)
+	@field:NotBlank
 	val periodDay: Long
 ) {
 	fun toData(): CreateStudentLinkRequestData =


### PR DESCRIPTION
## 💡 개요

학생정보 조회 링크 생성 API에서 최대로 지정할 수 있는 만료기간을 1 ~ 30일로 지정했습니다.