### PR TITLE
기업이 조회할 수 있는 링크를 생성할 때 발생하는 500 예외를 고쳤습니다.

### DIFF
--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/student/dto/req/CreateStudentLinkWebRequest.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/student/dto/req/CreateStudentLinkWebRequest.kt
@@ -4,12 +4,12 @@ import java.util.UUID
 import javax.validation.constraints.*
 
 data class CreateStudentLinkWebRequest (
-	@field:NotBlank
+	@field:NotNull
 	val studentId: UUID,
 
 	@field:Min(1)
 	@field:Max(30)
-	@field:NotBlank
+	@field:NotNull
 	val periodDay: Long
 ) {
 	fun toData(): CreateStudentLinkRequestData =


### PR DESCRIPTION
## 💡 배경 및 개요

링크 token을 생성할 때 문자열 타입만 검증할 수 있는 @NotBlank를 UUID 타입과 Long 타입의 변수를 검증할 때 사용하여 문제가 발생했습니다.

Resolves: #342 

## 📃 작업내용

@NotBlank -> @NotNull 변경

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
