### PR TITLE
학생 리스트 조회 시 캐시 문제 해결

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/FindAllUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/FindAllUseCase.kt
@@ -48,7 +48,8 @@ class FindAllUseCase(
     }
 
     fun generateCacheKey(page: Int, size: Int): String {
-        return "$page-$size"
+        val currentRole = securityService.getCurrentUserRole()
+        return "$page-$size:$currentRole"
     }
 }
 


### PR DESCRIPTION
## 💡 배경 및 개요

학생 리스트 조회 시 이전에 저장된 캐시가 남아있어 로그인 후에도 노** 와 같이 필터링 되거나, 로그아웃 후 이름이 그대로 노출되는 문제를 해결했습니다.

Resolves: #345 

## 📃 작업내용

캐싱 키에 Role 정보를 추가하여 Role 별로 조회 내용을 캐싱되도록 했습니다. 게스트와 학생, 선생님의 조회 결과를 각 Role에 맞게 되도록 변경했습니다!

## 🙋‍♂️ 리뷰노트

테스트하는데 왜 자꾸 STUDENT로 Role이 들어오나 했는데 쿠키가....🤨 꺠닫는데 조금 걸려서 이 시간에 올려요

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?