### PR TITLE
기존 인증제 폼 조회 -> 인증제 UUID로 인증제 정보를 조회하도록 변경

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/GetGroupAuthenticationAreaService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/GetGroupAuthenticationAreaService.kt
@@ -4,5 +4,5 @@ import team.msg.sms.domain.authentication.model.GroupAuthenticationArea
 import java.util.UUID
 
 interface GetGroupAuthenticationAreaService {
-    fun getGroupAuthenticationArea(): List<GroupAuthenticationArea>
+    fun getGroupAuthenticationAreaByAuthenticationFormId(authenticationFormId: UUID): List<GroupAuthenticationArea>
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/GetGroupAuthenticationAreaServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/GetGroupAuthenticationAreaServiceImpl.kt
@@ -4,12 +4,13 @@ import team.msg.sms.common.annotation.Service
 import team.msg.sms.domain.authentication.model.GroupAuthenticationArea
 import team.msg.sms.domain.authentication.service.GetGroupAuthenticationAreaService
 import team.msg.sms.domain.authentication.spi.GroupAuthenticationAreaPort
+import java.util.UUID
 
 @Service
 class GetGroupAuthenticationAreaServiceImpl(
     private val groupAuthenticationAreaPort: GroupAuthenticationAreaPort
 ) : GetGroupAuthenticationAreaService {
-    override fun getGroupAuthenticationArea(): List<GroupAuthenticationArea> =
-        groupAuthenticationAreaPort.queryGroupAuthenticationArea()
+    override fun getGroupAuthenticationAreaByAuthenticationFormId(authenticationFormId: UUID): List<GroupAuthenticationArea> =
+        groupAuthenticationAreaPort.queryGroupAuthenticationAreaByAuthenticationFormId(authenticationFormId)
 
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/QueryGroupAuthenticationAreaPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/QueryGroupAuthenticationAreaPort.kt
@@ -1,7 +1,8 @@
 package team.msg.sms.domain.authentication.spi
 
 import team.msg.sms.domain.authentication.model.GroupAuthenticationArea
+import java.util.UUID
 
 interface QueryGroupAuthenticationAreaPort {
-    fun queryGroupAuthenticationArea(): List<GroupAuthenticationArea>
+    fun queryGroupAuthenticationAreaByAuthenticationFormId(authenticationFormId: UUID): List<GroupAuthenticationArea>
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryAuthenticationFormUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryAuthenticationFormUseCase.kt
@@ -20,8 +20,8 @@ class QueryAuthenticationFormUseCase(
     private val groupAuthenticationAreaService: GroupAuthenticationAreaService
 ) {
     @Transactional(readOnly = true)
-    fun execute(): QueryAuthenticationFormResponseData {
-        val groups = groupAuthenticationAreaService.getGroupAuthenticationArea()
+    fun execute(authenticationFormId: UUID): QueryAuthenticationFormResponseData {
+        val groups = groupAuthenticationAreaService.getGroupAuthenticationAreaByAuthenticationFormId(authenticationFormId)
         val groupIds = groups.map { it.id }
         val files = fileService.getFileByTargetUuidsAndTypeEqualsAuthentication(targetIds = groupIds)
         val authenticationSections =

--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
@@ -86,6 +86,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.GET, "/").hasAnyAuthority(STUDENT, TEACHER)
             .antMatchers(HttpMethod.POST, "/submit/{uuid}").hasAuthority(STUDENT)
             .antMatchers(HttpMethod.POST, "/create").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication/form/{uuid}").hasAnyAuthority(STUDENT, TEACHER)
 
             .antMatchers(HttpMethod.POST, "/file").authenticated()
             .antMatchers(HttpMethod.POST, "/file/image").authenticated()

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/GroupAuthenticationAreaPersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/GroupAuthenticationAreaPersistenceAdapter.kt
@@ -7,13 +7,14 @@ import team.msg.sms.domain.authentication.spi.GroupAuthenticationAreaPort
 import team.msg.sms.persistence.authentication.mapper.toDomain
 import team.msg.sms.persistence.authentication.mapper.toEntity
 import team.msg.sms.persistence.authentication.repository.GroupAuthenticationAreaRepository
+import java.util.UUID
 
 @Component
 class GroupAuthenticationAreaPersistenceAdapter(
     private val groupAuthenticationAreaRepository: GroupAuthenticationAreaRepository
 ) : GroupAuthenticationAreaPort {
-    override fun queryGroupAuthenticationArea(): List<GroupAuthenticationArea> =
-        groupAuthenticationAreaRepository.findAll().sortedBy { it.sort }.map { it.toDomain() }
+    override fun queryGroupAuthenticationAreaByAuthenticationFormId(authenticationFormId: UUID): List<GroupAuthenticationArea> =
+        groupAuthenticationAreaRepository.findByAuthenticationFormId(authenticationFormId).sortedBy { it.sort }.map { it.toDomain() }
 
     override fun save(groupAuthenticationArea: GroupAuthenticationArea): GroupAuthenticationArea =
         groupAuthenticationAreaRepository.save(groupAuthenticationArea.toEntity()).toDomain()

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/repository/GroupAuthenticationAreaRepository.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/repository/GroupAuthenticationAreaRepository.kt
@@ -8,5 +8,5 @@ import java.util.UUID
 
 @Repository
 interface GroupAuthenticationAreaRepository : JpaRepository<GroupAuthenticationAreaJpaEntity, UUID> {
-    override fun findAll(): List<GroupAuthenticationAreaJpaEntity>
+    fun findByAuthenticationFormId(authenticationFormId: UUID): List<GroupAuthenticationAreaJpaEntity>
 }

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/AuthenticationWebAdapter.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/AuthenticationWebAdapter.kt
@@ -34,9 +34,9 @@ class AuthenticationWebAdapter(
     private val submitUserFormDataUseCase: SubmitUserFormDataUseCase,
     private val createAuthenticationFormUseCase: CreateAuthenticationFormUseCase
 ) {
-    @GetMapping
-    fun queryAuthenticationForm(): ResponseEntity<QueryAuthenticationFormWebResponse> =
-        queryAuthenticationFormUseCase.execute()
+    @GetMapping("/form/{uuid}")
+    fun queryAuthenticationForm(@PathVariable uuid: String): ResponseEntity<QueryAuthenticationFormWebResponse> =
+        queryAuthenticationFormUseCase.execute(UUID.fromString(uuid))
             .let { ResponseEntity.ok(it.toResponse()) }
 
     @PostMapping("/submit/{uuid}")


### PR DESCRIPTION
## 💡 배경 및 개요

인증제 폼 조회 시 UUID 키로 조회 하도록 변경하였습니다.

Resolves: #360 

## 📃 작업내용

tb_authentication 에서 가지는 UUID 키를 통해 조회 하여 추후 인증제를 선생님들이 여러개 만들어 확장하는데 있어 용이하도록 수정하였습니다.

## 🙋‍♂️ 리뷰노트

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [노션](https://www.notion.so/matsougeum/7597d344e0d84245acb6c7fa5c7c4c12?pvs=4) 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ✅ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ✅ ] 작업한 코드가 정상적으로 동작하나요?
- [ ✅ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
