### PR TITLE
🔀 확장명을 포함해서 저장하기

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/ModifyStudentPortfolioFileUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/ModifyStudentPortfolioFileUseCase.kt
@@ -32,7 +32,7 @@ class ModifyStudentPortfolioFileUseCase(
             )
 
             studentService.saveStudent(
-                student.copy(portfolioFileUrl = portfolioFileUrl, portfolioUrl = null),
+                student.copy(portfolioFileUrl = "${portfolioFileUrl}.pdf", portfolioUrl = null),
                 user
             )
         }


### PR DESCRIPTION
## 💡 배경 및 개요
pdf 파일을 저장할 때 확장자를 저장하지 않은 문제를 해결했습니다.
https://asdf.sadf/asdf -> https://asdf.asdf/asdf.pdf

Resolves: #378