### PR TITLE
🔀 학생정보 수정 API 접근 권한 추가

### DIFF
--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
@@ -45,59 +45,66 @@ class SecurityConfig(
             .requestMatchers(RequestMatcher { request ->
                 CorsUtils.isPreFlightRequest(request)
             }).permitAll()
-            //healthCheck
+            // Health
             .antMatchers(HttpMethod.GET, "/health").permitAll()
 
-            // auth
+            // Auth
+            .antMatchers(HttpMethod.GET, "/auth/verity/access").authenticated()
             .antMatchers(HttpMethod.POST, "/auth").permitAll()
             .antMatchers(HttpMethod.PATCH, "/auth").permitAll()
             .antMatchers(HttpMethod.DELETE, "/auth").authenticated()
-            .antMatchers(HttpMethod.GET, "/auth/verity/access").authenticated()
             .antMatchers(HttpMethod.DELETE, "/auth/withdrawal").authenticated()
 
-            .antMatchers(HttpMethod.GET, "/user/profile/img").permitAll()
-            .antMatchers(HttpMethod.GET, "/user/profile").hasAuthority(STUDENT)
-
-            .antMatchers(HttpMethod.POST, "/student").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.GET, "/student").permitAll()
-            .antMatchers(HttpMethod.POST, "/student/link").hasAuthority(TEACHER)
+            // Student
             .antMatchers(HttpMethod.GET, "/student/link").permitAll()
             .antMatchers(HttpMethod.GET, "/student/{uuid}").hasAnyAuthority(STUDENT, TEACHER)
-            .antMatchers(HttpMethod.PUT, "/student").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.PUT, "/student/pdf").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.GET, "/student/teacher/{uuid}").hasAuthority(TEACHER)
             .antMatchers(HttpMethod.GET, "/student/anonymous/{uuid}").permitAll()
+            .antMatchers(HttpMethod.GET, "/student/teacher/{uuid}").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.GET, "/student").permitAll()
+            .antMatchers(HttpMethod.PUT, "/student/pdf").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.PUT, "/student").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.POST, "/student").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.POST, "/student/link").hasAuthority(TEACHER)
 
+            // Teacher
             .antMatchers(HttpMethod.POST, "/teacher/common").hasAuthority(TEACHER)
             .antMatchers(HttpMethod.POST, "/teacher/director").hasAuthority(TEACHER)
             .antMatchers(HttpMethod.POST, "/teacher/homeroom").hasAuthority(TEACHER)
             .antMatchers(HttpMethod.POST, "/teacher/principal").hasAuthority(TEACHER)
             .antMatchers(HttpMethod.POST, "/teacher/deputy-principal").hasAuthority(TEACHER)
 
-            .antMatchers(HttpMethod.GET, "/authentication/student/{student_uuid}").hasAuthority(TEACHER)
-            .antMatchers(HttpMethod.GET, "/authentication/teacher").hasAuthority(TEACHER)
-            .antMatchers(HttpMethod.PATCH, "/authentication/teacher/{uuid}/approve").hasAuthority(TEACHER)
-            .antMatchers(HttpMethod.PATCH, "/authentication/teacher/{uuid}/reject").hasAuthority(TEACHER)
-            .antMatchers(HttpMethod.GET, "/authentication/teacher/{uuid}").hasAuthority(TEACHER)
-            .antMatchers(HttpMethod.GET, "/authentication/{uuid}/history").hasAnyAuthority(STUDENT, TEACHER)
-            .antMatchers(HttpMethod.GET, "/authentication/my").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.POST, "/authentication").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.GET, "/authentication/{uuid}").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.DELETE, "/authentication/{uuid}").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.PATCH, "/authentication/{uuid}").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.PUT, "/authentication/{uuid}").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.GET, "/").hasAnyAuthority(STUDENT, TEACHER)
-            .antMatchers(HttpMethod.POST, "/authentication/submit/{uuid}").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.POST, "/authentication/create").hasAuthority(TEACHER)
-            .antMatchers(HttpMethod.GET, "/authentication/form/{uuid}").hasAnyAuthority(STUDENT, TEACHER)
-            .antMatchers(HttpMethod.GET, "/authentication").hasAuthority(TEACHER)
-
+            // File
             .antMatchers(HttpMethod.POST, "/file").authenticated()
             .antMatchers(HttpMethod.POST, "/file/image").authenticated()
 
+            // Major
             .antMatchers(HttpMethod.GET, "/major/list").permitAll()
 
+            // Stack
             .antMatchers(HttpMethod.GET, "/stack/list").permitAll()
+
+            // User
+            .antMatchers(HttpMethod.GET, "/user/profile/img").permitAll()
+            .antMatchers(HttpMethod.GET, "/user/profile").hasAuthority(STUDENT)
+
+            // Authentication
+            .antMatchers(HttpMethod.GET, "/authentication/student/{student_uuid}").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication/teacher").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication/teacher/{uuid}").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication/{uuid}/history").hasAnyAuthority(STUDENT, TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication/my").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.GET, "/authentication/{uuid}").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.GET, "/").hasAnyAuthority(STUDENT, TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication/form/{uuid}").hasAnyAuthority(STUDENT, TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.PUT, "/authentication/{uuid}").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.POST, "/authentication").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.POST, "/authentication/submit/{uuid}").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.POST, "/authentication/create").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.PATCH, "/authentication/teacher/{uuid}/approve").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.PATCH, "/authentication/teacher/{uuid}/reject").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.PATCH, "/authentication/{uuid}").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.DELETE, "/authentication/{uuid}").hasAuthority(STUDENT)
 
             .anyRequest().denyAll()
 

--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
@@ -63,6 +63,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.POST, "/student/link").hasAuthority(TEACHER)
             .antMatchers(HttpMethod.GET, "/student/link").permitAll()
             .antMatchers(HttpMethod.GET, "/student/{uuid}").hasAnyAuthority(STUDENT, TEACHER)
+            .antMatchers(HttpMethod.PUT, "/student").hasAuthority(STUDENT)
             .antMatchers(HttpMethod.PUT, "/student/pdf").hasAuthority(STUDENT)
             .antMatchers(HttpMethod.GET, "/student/anonymous/{uuid}").permitAll()
 

--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
@@ -65,6 +65,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.GET, "/student/{uuid}").hasAnyAuthority(STUDENT, TEACHER)
             .antMatchers(HttpMethod.PUT, "/student").hasAuthority(STUDENT)
             .antMatchers(HttpMethod.PUT, "/student/pdf").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.GET, "/student/teacher/{uuid}").hasAuthority(TEACHER)
             .antMatchers(HttpMethod.GET, "/student/anonymous/{uuid}").permitAll()
 
             .antMatchers(HttpMethod.POST, "/teacher/common").hasAuthority(TEACHER)


### PR DESCRIPTION
## 💡 배경 및 개요

/student PUT에서 403 에러가 생긴다는 말을 들었고 코드를 확인해보니 /student PUT (학생정보 수정)에 대한 경로 접근 권한이 없는 것을 확인했습니다. + (이외에도 추가되지 않은 경로에 대한 권한을 추가하였습니다.)

Resolves: #380 

## 📃 작업내용

- SecurityConfig에 /student PUT 경로 권한 추가하기
- SecurityConfig에 /student/teacher/{uuid} GET 경로 권한 추가하기