### PR TITLE
학생이 제출한 폼 상세 조회 기능 개발

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/dto/res/StudentAuthenticationFormResponseData.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/dto/res/StudentAuthenticationFormResponseData.kt
@@ -1,5 +1,6 @@
 package team.msg.sms.domain.authentication.dto.res
 
+import team.msg.sms.domain.authentication.model.FieldType
 import java.util.UUID
 
 data class StudentAuthenticationFormResponseData(
@@ -30,6 +31,7 @@ data class StudentAuthenticationFormResponseData(
     )
     data class Field(
         val fieldId: UUID,
+        val fieldType: FieldType,
         val value: String?
     )
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/dto/res/StudentAuthenticationFormResponseData.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/dto/res/StudentAuthenticationFormResponseData.kt
@@ -1,0 +1,35 @@
+package team.msg.sms.domain.authentication.dto.res
+
+import java.util.UUID
+
+data class StudentAuthenticationFormResponseData(
+    val markingBoardId: UUID,
+    val title: String,
+    val content: List<Area>
+) {
+    data class Area(
+        val areaId: UUID,
+        val areaTitle: String,
+        val sections: List<Section>
+    )
+    data class Section(
+        val sectionId: UUID,
+        val sectionName: String,
+        val maxCount: Int,
+        val groups: List<Group>
+    )
+    data class Group(
+        val groupId: UUID,
+        val maxScore: Double,
+        val fields: List<FieldSet>
+    )
+
+    data class FieldSet(
+        val setId: UUID,
+        val values: List<Field>
+    )
+    data class Field(
+        val fieldId: UUID,
+        val value: String?
+    )
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/exception/MarkingBoardNotFoundException.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/exception/MarkingBoardNotFoundException.kt
@@ -1,0 +1,8 @@
+package team.msg.sms.domain.authentication.exception
+
+import team.msg.sms.common.error.SmsException
+import team.msg.sms.domain.authentication.exception.error.AuthenticationErrorCode
+
+object MarkingBoardNotFoundException : SmsException(
+    AuthenticationErrorCode.MARKING_BOARD_NOT_FOUND
+)

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/exception/error/AuthenticationErrorCode.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/exception/error/AuthenticationErrorCode.kt
@@ -14,7 +14,8 @@ enum class AuthenticationErrorCode(
     ONLY_ACCESS_MYSELF(ErrorStatus.FORBIDDEN, "자기 자신만 조회할 수 있습니다."),
     INVALID_GRADE_CLASS(ErrorStatus.FORBIDDEN, "담임 선생님만 조회할 수 있습니다."),
     ALREADY_GIVEN_SCORE(ErrorStatus.CONFLICT, "이미 활동에 점수가 부여되었습니다."),
-    NO_REQUESTED_ACTIVITY(ErrorStatus.CONFLICT, "활동이 아직 요청되지 않았습니다.")
+    NO_REQUESTED_ACTIVITY(ErrorStatus.CONFLICT, "활동이 아직 요청되지 않았습니다."),
+    MARKING_BOARD_NOT_FOUND(ErrorStatus.NOT_FOUND, "학생이 제출한 폼이 조회되지 않습니다.")
     ;
 
     override fun status(): Int = status

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/model/UserFormValue.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/model/UserFormValue.kt
@@ -7,7 +7,7 @@ import java.util.UUID
 @Aggregate
 class UserFormValue(
     val id: UUID,
-    val setId: UUID?,
+    val setId: UUID,
     val authenticationFieldGroupId: UUID,
     val authenticationSectionId: UUID,
     val authenticationFieldId: UUID,

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/GetMarkingBoardService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/GetMarkingBoardService.kt
@@ -1,10 +1,12 @@
 package team.msg.sms.domain.authentication.service
 
 import team.msg.sms.domain.authentication.dto.res.UserBoardPageResponseData
+import team.msg.sms.domain.authentication.model.MarkingBoard
 import team.msg.sms.domain.authentication.model.MarkingBoardType
 import java.util.*
 
 interface GetMarkingBoardService {
+    fun getMarkingBoardById(id: UUID): MarkingBoard
     fun getMarkingBoardByStudentIds(
         studentIds: List<UUID>,
         authenticationId: UUID,

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/GetUserFormValueService.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/GetUserFormValueService.kt
@@ -1,4 +1,11 @@
 package team.msg.sms.domain.authentication.service
 
+import team.msg.sms.domain.authentication.model.UserFormValue
+import java.util.UUID
+
 interface GetUserFormValueService {
+    fun getUserFormValueListByFieldIdAndStudentId(
+        fieldId: UUID,
+        studentId: UUID
+    ): List<UserFormValue>
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/GetAuthenticationSectionServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/GetAuthenticationSectionServiceImpl.kt
@@ -12,8 +12,8 @@ class GetAuthenticationSectionServiceImpl(
     private val authenticationSectionPort: AuthenticationSectionPort
 ) : GetAuthenticationSectionService {
     override fun getAuthenticationSectionByGroupIds(groupIds: List<UUID>): List<AuthenticationSection> =
-        authenticationSectionPort.getAuthenticationSectionByGroupIds(groupIds)
+        authenticationSectionPort.queryAuthenticationSectionByGroupIds(groupIds)
 
     override fun getMaxCountById(sectionId: UUID): Int =
-        authenticationSectionPort.getMaxCountById(id = sectionId) ?: throw InternalServerErrorException
+        authenticationSectionPort.queryMaxCountById(id = sectionId) ?: throw InternalServerErrorException
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/GetMarkingBoardServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/GetMarkingBoardServiceImpl.kt
@@ -3,6 +3,8 @@ package team.msg.sms.domain.authentication.service.impl
 import team.msg.sms.common.annotation.Service
 import team.msg.sms.domain.authentication.dto.res.UserBoardPageResponseData
 import team.msg.sms.domain.authentication.dto.res.UserBoardWithStudentInfoResponseData
+import team.msg.sms.domain.authentication.exception.MarkingBoardNotFoundException
+import team.msg.sms.domain.authentication.model.MarkingBoard
 import team.msg.sms.domain.authentication.model.MarkingBoardType
 import team.msg.sms.domain.authentication.service.GetMarkingBoardService
 import team.msg.sms.domain.authentication.spi.MarkingBoardPort
@@ -12,6 +14,10 @@ import java.util.UUID
 class GetMarkingBoardServiceImpl(
     private val markingBoardPort: MarkingBoardPort
 ) : GetMarkingBoardService {
+    override fun getMarkingBoardById(id: UUID): MarkingBoard {
+        return markingBoardPort.queryMarkingBoardById(id) ?: throw MarkingBoardNotFoundException
+    }
+
     override fun getMarkingBoardByStudentIds(
         studentIds: List<UUID>,
         authenticationId: UUID,

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/GetUserFormValueServiceImpl.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/service/impl/GetUserFormValueServiceImpl.kt
@@ -1,11 +1,15 @@
 package team.msg.sms.domain.authentication.service.impl
 
 import team.msg.sms.common.annotation.Service
+import team.msg.sms.domain.authentication.model.UserFormValue
 import team.msg.sms.domain.authentication.service.GetUserFormValueService
 import team.msg.sms.domain.authentication.spi.UserFormValuePort
+import java.util.*
 
 @Service
 class GetUserFormValueServiceImpl(
     private val userFormValuePort: UserFormValuePort
 ) : GetUserFormValueService {
+    override fun getUserFormValueListByFieldIdAndStudentId(fieldId: UUID, studentId: UUID): List<UserFormValue> =
+        userFormValuePort.queryUserFormValueListByFieldIdAndStudentId(fieldId, studentId)
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/QueryAuthenticationSectionPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/QueryAuthenticationSectionPort.kt
@@ -4,6 +4,6 @@ import team.msg.sms.domain.authentication.model.AuthenticationSection
 import java.util.UUID
 
 interface QueryAuthenticationSectionPort {
-    fun getAuthenticationSectionByGroupIds(groupIds: List<UUID>): List<AuthenticationSection>
-    fun getMaxCountById(id: UUID): Int?
+    fun queryAuthenticationSectionByGroupIds(groupIds: List<UUID>): List<AuthenticationSection>
+    fun queryMaxCountById(id: UUID): Int?
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/QueryMarkingBoardPort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/QueryMarkingBoardPort.kt
@@ -1,10 +1,12 @@
 package team.msg.sms.domain.authentication.spi
 
 import team.msg.sms.domain.authentication.dto.res.UserBoardPageResponseData
+import team.msg.sms.domain.authentication.model.MarkingBoard
 import team.msg.sms.domain.authentication.model.MarkingBoardType
 import java.util.UUID
 
 interface QueryMarkingBoardPort {
+    fun queryMarkingBoardById(id: UUID): MarkingBoard?
     fun queryMarkingBoardByStudentIds(
         studentIds: List<UUID>,
         authenticationId: UUID,

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/QueryUserFormValuePort.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/spi/QueryUserFormValuePort.kt
@@ -1,4 +1,8 @@
 package team.msg.sms.domain.authentication.spi
 
+import team.msg.sms.domain.authentication.model.UserFormValue
+import java.util.UUID
+
 interface QueryUserFormValuePort {
+    fun queryUserFormValueListByFieldIdAndStudentId(fieldId: UUID, studentId: UUID): List<UserFormValue>
 }

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryAuthenticationFormUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryAuthenticationFormUseCase.kt
@@ -20,10 +20,12 @@ class QueryAuthenticationFormUseCase(
     private val selectorSectionValueService: SelectorSectionValueService,
     private val authenticationFieldService: AuthenticationFieldService,
     private val authenticationAreaService: AuthenticationAreaService,
-    private val authenticationFieldGroupService: AuthenticationFieldGroupService
+    private val authenticationFieldGroupService: AuthenticationFieldGroupService,
+    private val authenticationFormService: AuthenticationFormService
 ) {
     @Transactional(readOnly = true)
-    fun execute(authenticationFormId: UUID): QueryAuthenticationFormResponseData {
+    fun execute(): QueryAuthenticationFormResponseData {
+        val authenticationFormId = authenticationFormService.getActiveAuthenticationFormId()
         val files = fetchFiles(authenticationFormId)
         val groups = fetchAuthenticationGroups(authenticationFormId)
         val authenticationSections = fetchAuthenticationSections(groups)

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryStudentAuthenticationFormDetailUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryStudentAuthenticationFormDetailUseCase.kt
@@ -1,0 +1,125 @@
+package team.msg.sms.domain.authentication.usecase
+
+import team.msg.sms.common.annotation.ReadOnlyUseCase
+import team.msg.sms.domain.authentication.dto.res.StudentAuthenticationFormResponseData
+import team.msg.sms.domain.authentication.model.AuthenticationArea
+import team.msg.sms.domain.authentication.model.AuthenticationSection
+import team.msg.sms.domain.authentication.model.SelectorSectionValue
+import team.msg.sms.domain.authentication.model.UserFormValue
+import team.msg.sms.domain.authentication.service.*
+import java.util.UUID
+
+@ReadOnlyUseCase
+class QueryStudentAuthenticationFormDetailUseCase(
+    private val markingBoardService: MarkingBoardService,
+    private val authenticationAreaService: AuthenticationAreaService,
+    private val authenticationSectionService: AuthenticationSectionService,
+    private val authenticationFieldGroupService: AuthenticationFieldGroupService,
+    private val authenticationFieldService: AuthenticationFieldService,
+    private val userFormValueService: UserFormValueService,
+    private val selectorSectionValueService: SelectorSectionValueService
+) {
+    fun execute(markingBoardId: UUID): StudentAuthenticationFormResponseData {
+        val markingBoard = markingBoardService.getMarkingBoardById(id = markingBoardId)
+
+        val authenticationAreas =
+            authenticationAreaService.getGroupAuthenticationAreaByAuthenticationFormId(markingBoard.authenticationId)
+
+        val authenticationSections =
+            authenticationSectionService.getAuthenticationSectionByGroupIds(authenticationAreas.map { it.id })
+
+        val selectorSectionValues = selectorSectionValueService.getSelectorSectionValue()
+
+        return StudentAuthenticationFormResponseData(
+            markingBoardId = markingBoard.id,
+            title = markingBoard.title,
+            content = buildAreas(
+                authenticationAreas,
+                authenticationSections,
+                selectorSectionValues,
+                markingBoard.studentId
+            )
+        )
+    }
+    private fun buildAreas(
+        authenticationAreas: List<AuthenticationArea>,
+        authenticationSections: List<AuthenticationSection>,
+        selectorSectionValues: List<SelectorSectionValue>,
+        studentId: UUID
+    ): List<StudentAuthenticationFormResponseData.Area> {
+        return authenticationAreas.map { area ->
+            StudentAuthenticationFormResponseData.Area(
+                areaId = area.id,
+                areaTitle = area.title,
+                sections = buildSections(area.id, authenticationSections, selectorSectionValues, studentId)
+            )
+        }
+    }
+
+    private fun buildSections(
+        areaId: UUID,
+        authenticationSections: List<AuthenticationSection>,
+        selectorSectionValues: List<SelectorSectionValue>,
+        studentId: UUID
+    ): List<StudentAuthenticationFormResponseData.Section> {
+        return authenticationSections.filter { it.groupId == areaId }
+            .map { section ->
+                StudentAuthenticationFormResponseData.Section(
+                    sectionId = section.id,
+                    sectionName = section.sectionName,
+                    maxCount = section.maxCount,
+                    groups = buildGroups(section.id, selectorSectionValues, studentId)
+                )
+            }
+    }
+
+    private fun buildGroups(
+        sectionId: UUID,
+        selectorSectionValues: List<SelectorSectionValue>,
+        studentId: UUID
+    ): List<StudentAuthenticationFormResponseData.Group> {
+        return authenticationFieldGroupService.findAuthenticationFieldGroupBySectionId(sectionId)
+            .map { fieldGroup ->
+                StudentAuthenticationFormResponseData.Group(
+                    groupId = fieldGroup.id,
+                    maxScore = fieldGroup.maxScore,
+                    fields = buildFieldSets(fieldGroup.id, selectorSectionValues, studentId)
+                )
+            }
+    }
+
+    private fun buildFieldSets(
+        groupId: UUID,
+        selectorSectionValues: List<SelectorSectionValue>,
+        studentId: UUID
+    ): List<StudentAuthenticationFormResponseData.FieldSet> {
+        return authenticationFieldService.getAuthenticationFieldsByGroupId(groupId)
+            .flatMap { authenticationField ->
+                val userFormValues =
+                    userFormValueService.getUserFormValueListByFieldIdAndStudentId(authenticationField.id, studentId)
+                val setIds = userFormValues.map { it.setId }.distinct()
+                setIds.map { setId ->
+                    StudentAuthenticationFormResponseData.FieldSet(
+                        setId = setId,
+                        values = buildFields(userFormValues, setId, selectorSectionValues)
+                    )
+                }
+            }
+    }
+
+    private fun buildFields(
+        userFormValues: List<UserFormValue>,
+        setId: UUID,
+        selectorSectionValues: List<SelectorSectionValue>
+    ): List<StudentAuthenticationFormResponseData.Field> {
+        return userFormValues.filter { it.setId == setId }
+            .map { userFormValue ->
+                StudentAuthenticationFormResponseData.Field(
+                    fieldId = userFormValue.authenticationFieldId,
+                    value = userFormValue.targetId?.let { targetId ->
+                        selectorSectionValues.find { it.id == targetId }?.name
+                    } ?: userFormValue.value
+                )
+            }
+    }
+}

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryStudentAuthenticationFormDetailUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryStudentAuthenticationFormDetailUseCase.kt
@@ -124,6 +124,7 @@ class QueryStudentAuthenticationFormDetailUseCase(
             .map { userFormValue ->
                 StudentAuthenticationFormResponseData.Field(
                     fieldId = userFormValue.authenticationFieldId,
+                    fieldType = userFormValue.fieldType,
                     value = userFormValue.targetId?.let { targetId ->
                         selectorSectionValues.find { it.id == targetId }?.name
                     } ?: userFormValue.value

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/SubmitUserFormDataUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/SubmitUserFormDataUseCase.kt
@@ -16,17 +16,16 @@ import java.util.*
 @UseCase
 class SubmitUserFormDataUseCase(
     private val userFormValueService: UserFormValueService,
-    private val authenticationSectionService: AuthenticationSectionService,
     private val markingBoardService: MarkingBoardService,
     private val studentService: StudentService
 ) {
     fun execute(submitDataList: List<SubmitUserFormRequestData>, authenticationFormId: UUID) {
         val student = studentService.currentStudent()
         val userFormValues = submitDataList.flatMap { submitData ->
-            val maxCount = authenticationSectionService.getMaxCountById(submitData.sectionId)
-            val groupId = if (maxCount > 1) UUID.randomUUID() else null
 
             submitData.objects.flatMap { submitValue ->
+                val groupId = UUID.randomUUID()
+
                 submitValue.fields.map { submitFieldValue ->
                     createUserFormValue(
                         sectionId = submitData.sectionId,
@@ -54,7 +53,7 @@ class SubmitUserFormDataUseCase(
     private fun createUserFormValue(
         sectionId: UUID,
         submitData: SubmitUserFormRequestData.SubmitFieldValueRequestData,
-        groupId: UUID?,
+        groupId: UUID,
         authenticationFieldGroupId: UUID,
         studentId: UUID,
         authenticationFormId: UUID

--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
@@ -87,9 +87,9 @@ class SecurityConfig(
             .antMatchers(HttpMethod.GET, "/").hasAnyAuthority(STUDENT, TEACHER)
             .antMatchers(HttpMethod.POST, "/authentication/submit/{uuid}").hasAuthority(STUDENT)
             .antMatchers(HttpMethod.POST, "/authentication/create").hasAuthority(TEACHER)
-            .antMatchers(HttpMethod.GET, "/authentication/form/{uuid}").hasAnyAuthority(STUDENT, TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication/form").hasAnyAuthority(STUDENT, TEACHER)
             .antMatchers(HttpMethod.GET, "/authentication").hasAuthority(TEACHER)
-            .antMatchers(HttpMethod.GET, "/authentication/{uuid}/form").hasAnyAuthority(STUDENT, TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication/{uuid}/form").hasAuthority(TEACHER)
 
             .antMatchers(HttpMethod.POST, "/file").authenticated()
             .antMatchers(HttpMethod.POST, "/file/image").authenticated()

--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
@@ -89,6 +89,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.POST, "/authentication/create").hasAuthority(TEACHER)
             .antMatchers(HttpMethod.GET, "/authentication/form/{uuid}").hasAnyAuthority(STUDENT, TEACHER)
             .antMatchers(HttpMethod.GET, "/authentication").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication/{uuid}/form").hasAnyAuthority(STUDENT, TEACHER)
 
             .antMatchers(HttpMethod.POST, "/file").authenticated()
             .antMatchers(HttpMethod.POST, "/file/image").authenticated()

--- a/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
+++ b/sms-infrastructure/src/main/kotlin/team/msg/sms/global/security/SecurityConfig.kt
@@ -45,58 +45,67 @@ class SecurityConfig(
             .requestMatchers(RequestMatcher { request ->
                 CorsUtils.isPreFlightRequest(request)
             }).permitAll()
-            //healthCheck
+            // Health
             .antMatchers(HttpMethod.GET, "/health").permitAll()
 
-            // auth
+            // Auth
+            .antMatchers(HttpMethod.GET, "/auth/verity/access").authenticated()
             .antMatchers(HttpMethod.POST, "/auth").permitAll()
             .antMatchers(HttpMethod.PATCH, "/auth").permitAll()
             .antMatchers(HttpMethod.DELETE, "/auth").authenticated()
-            .antMatchers(HttpMethod.GET, "/auth/verity/access").authenticated()
             .antMatchers(HttpMethod.DELETE, "/auth/withdrawal").authenticated()
 
-            .antMatchers(HttpMethod.GET, "/user/profile/img").permitAll()
-            .antMatchers(HttpMethod.GET, "/user/profile").hasAuthority(STUDENT)
-
-            .antMatchers(HttpMethod.POST, "/student").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.GET, "/student").permitAll()
-            .antMatchers(HttpMethod.POST, "/student/link").hasAuthority(TEACHER)
+            // Student
             .antMatchers(HttpMethod.GET, "/student/link").permitAll()
             .antMatchers(HttpMethod.GET, "/student/{uuid}").hasAnyAuthority(STUDENT, TEACHER)
-            .antMatchers(HttpMethod.PUT, "/student/pdf").hasAuthority(STUDENT)
             .antMatchers(HttpMethod.GET, "/student/anonymous/{uuid}").permitAll()
+            .antMatchers(HttpMethod.GET, "/student/teacher/{uuid}").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.GET, "/student").permitAll()
+            .antMatchers(HttpMethod.PUT, "/student/pdf").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.PUT, "/student").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.POST, "/student").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.POST, "/student/link").hasAuthority(TEACHER)
 
+            // Teacher
             .antMatchers(HttpMethod.POST, "/teacher/common").hasAuthority(TEACHER)
             .antMatchers(HttpMethod.POST, "/teacher/director").hasAuthority(TEACHER)
             .antMatchers(HttpMethod.POST, "/teacher/homeroom").hasAuthority(TEACHER)
             .antMatchers(HttpMethod.POST, "/teacher/principal").hasAuthority(TEACHER)
             .antMatchers(HttpMethod.POST, "/teacher/deputy-principal").hasAuthority(TEACHER)
 
-            .antMatchers(HttpMethod.GET, "/authentication/student/{student_uuid}").hasAuthority(TEACHER)
-            .antMatchers(HttpMethod.GET, "/authentication/teacher").hasAuthority(TEACHER)
-            .antMatchers(HttpMethod.PATCH, "/authentication/teacher/{uuid}/approve").hasAuthority(TEACHER)
-            .antMatchers(HttpMethod.PATCH, "/authentication/teacher/{uuid}/reject").hasAuthority(TEACHER)
-            .antMatchers(HttpMethod.GET, "/authentication/teacher/{uuid}").hasAuthority(TEACHER)
-            .antMatchers(HttpMethod.GET, "/authentication/{uuid}/history").hasAnyAuthority(STUDENT, TEACHER)
-            .antMatchers(HttpMethod.GET, "/authentication/my").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.POST, "/authentication").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.GET, "/authentication/{uuid}").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.DELETE, "/authentication/{uuid}").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.PATCH, "/authentication/{uuid}").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.PUT, "/authentication/{uuid}").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.GET, "/").hasAnyAuthority(STUDENT, TEACHER)
-            .antMatchers(HttpMethod.POST, "/authentication/submit/{uuid}").hasAuthority(STUDENT)
-            .antMatchers(HttpMethod.POST, "/authentication/create").hasAuthority(TEACHER)
-            .antMatchers(HttpMethod.GET, "/authentication/form").hasAnyAuthority(STUDENT, TEACHER)
-            .antMatchers(HttpMethod.GET, "/authentication").hasAuthority(TEACHER)
-            .antMatchers(HttpMethod.GET, "/authentication/{uuid}/form").hasAuthority(TEACHER)
-
+            // File
             .antMatchers(HttpMethod.POST, "/file").authenticated()
             .antMatchers(HttpMethod.POST, "/file/image").authenticated()
 
+            // Major
             .antMatchers(HttpMethod.GET, "/major/list").permitAll()
 
+            // Stack
             .antMatchers(HttpMethod.GET, "/stack/list").permitAll()
+
+            // User
+            .antMatchers(HttpMethod.GET, "/user/profile/img").permitAll()
+            .antMatchers(HttpMethod.GET, "/user/profile").hasAuthority(STUDENT)
+
+            // Authentication
+            .antMatchers(HttpMethod.GET, "/authentication/student/{student_uuid}").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication/teacher").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication/teacher/{uuid}").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication/{uuid}/history").hasAnyAuthority(STUDENT, TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication/my").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.GET, "/authentication/{uuid}").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.GET, "/").hasAnyAuthority(STUDENT, TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication/form").hasAnyAuthority(STUDENT, TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication/{uuid}/form").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.GET, "/authentication").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.PUT, "/authentication/{uuid}").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.POST, "/authentication").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.POST, "/authentication/submit/{uuid}").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.POST, "/authentication/create").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.PATCH, "/authentication/teacher/{uuid}/approve").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.PATCH, "/authentication/teacher/{uuid}/reject").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.PATCH, "/authentication/{uuid}").hasAuthority(STUDENT)
+            .antMatchers(HttpMethod.DELETE, "/authentication/{uuid}").hasAuthority(STUDENT)
 
             .anyRequest().denyAll()
 
@@ -111,4 +120,3 @@ class SecurityConfig(
         return http.build()
     }
 }
-

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/AuthenticationSectionPersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/AuthenticationSectionPersistenceAdapter.kt
@@ -14,10 +14,11 @@ class AuthenticationSectionPersistenceAdapter(
     private val authenticationSectionRepositoryCustom: AuthenticationSectionRepositoryCustom,
     private val authenticationSectionJpaRepository: AuthenticationSectionJpaRepository
 ) : AuthenticationSectionPort {
-    override fun getAuthenticationSectionByGroupIds(groupIds: List<UUID>): List<AuthenticationSection> =
+
+    override fun queryAuthenticationSectionByGroupIds(groupIds: List<UUID>): List<AuthenticationSection> =
         authenticationSectionRepositoryCustom.getAuthenticationSectionByGroupIds(groupIds).map { it.toDomain() }
 
-    override fun getMaxCountById(id: UUID): Int? = authenticationSectionRepositoryCustom.findMaxCountById(id)
+    override fun queryMaxCountById(id: UUID): Int? = authenticationSectionRepositoryCustom.findMaxCountById(id)
 
 
     override fun save(authenticationSection: AuthenticationSection): AuthenticationSection =

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/MarkingBoardPersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/MarkingBoardPersistenceAdapter.kt
@@ -1,11 +1,12 @@
 package team.msg.sms.persistence.authentication
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import team.msg.sms.domain.authentication.dto.res.UserBoardPageResponseData
-import team.msg.sms.domain.authentication.dto.res.UserBoardWithStudentInfoResponseData
 import team.msg.sms.domain.authentication.model.MarkingBoard
 import team.msg.sms.domain.authentication.model.MarkingBoardType
 import team.msg.sms.domain.authentication.spi.MarkingBoardPort
+import team.msg.sms.persistence.authentication.mapper.toDomain
 import team.msg.sms.persistence.authentication.mapper.toEntity
 import team.msg.sms.persistence.authentication.repository.MarkingBoardJpaRepository
 import team.msg.sms.persistence.authentication.repository.queryDSL.MarkingBoardCustomRepository
@@ -19,6 +20,10 @@ class MarkingBoardPersistenceAdapter(
     override fun save(markingBoard: MarkingBoard) {
         markingBoardJpaRepository.save(markingBoard.toEntity())
     }
+
+    override fun queryMarkingBoardById(id: UUID): MarkingBoard? =
+        markingBoardJpaRepository.findByIdOrNull(id)?.toDomain()
+
 
     override fun queryMarkingBoardByStudentIds(
         studentIds: List<UUID>,

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/UserFormValuePersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/UserFormValuePersistenceAdapter.kt
@@ -6,11 +6,16 @@ import team.msg.sms.domain.authentication.spi.UserFormValuePort
 import team.msg.sms.persistence.authentication.mapper.toDomain
 import team.msg.sms.persistence.authentication.mapper.toEntity
 import team.msg.sms.persistence.authentication.repository.UserFormValueRepository
+import java.util.*
 
 @Component
 class UserFormValuePersistenceAdapter(
     private val userFormValueRepository: UserFormValueRepository
 ) : UserFormValuePort {
+    override fun queryUserFormValueListByFieldIdAndStudentId(fieldId: UUID, studentId: UUID): List<UserFormValue> {
+        return userFormValueRepository.findAllByAuthenticationFieldIdAndCreatedBy(fieldId, studentId).map { it.toDomain() }
+    }
+
     override fun saveAll(userFormValueList: List<UserFormValue>): List<UserFormValue> {
         return userFormValueRepository.saveAll(userFormValueList.map { it.toEntity() })
             .map { it.toDomain() }

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/entity/UserFormValueJpaEntity.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/entity/UserFormValueJpaEntity.kt
@@ -13,7 +13,7 @@ class UserFormValueJpaEntity(
     override val id: UUID,
 
     @Column(columnDefinition = "BINARY(16)")
-    val setId: UUID?,
+    val setId: UUID,
 
     @Column(columnDefinition = "BINARY(16)", nullable = false)
     val authenticationSectionId: UUID,

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/repository/UserFormValueRepository.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/repository/UserFormValueRepository.kt
@@ -7,4 +7,5 @@ import java.util.UUID
 
 @Repository
 interface UserFormValueRepository : CrudRepository<UserFormValueJpaEntity, UUID> {
+    fun findAllByAuthenticationFieldIdAndCreatedBy(fieldId: UUID, createdBy: UUID): List<UserFormValueJpaEntity>
 }

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/AuthenticationWebAdapter.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/AuthenticationWebAdapter.kt
@@ -30,7 +30,8 @@ class AuthenticationWebAdapter(
     private val queryAuthenticationFormUseCase: QueryAuthenticationFormUseCase,
     private val submitUserFormDataUseCase: SubmitUserFormDataUseCase,
     private val createAuthenticationFormUseCase: CreateAuthenticationFormUseCase,
-    private val queryStudentFormListUseCase: QueryStudentFormListUseCase
+    private val queryStudentFormListUseCase: QueryStudentFormListUseCase,
+    private val queryStudentAuthenticationFormDetailUseCase: QueryStudentAuthenticationFormDetailUseCase
 ) {
     @GetMapping("/form/{uuid}")
     fun queryAuthenticationForm(@PathVariable uuid: String): ResponseEntity<QueryAuthenticationFormWebResponse> =
@@ -46,6 +47,13 @@ class AuthenticationWebAdapter(
         return queryStudentFormListUseCase.execute(page, size, type)
             .let { ResponseEntity.ok(it.toResponse()) }
     }
+
+    @GetMapping("/{uuid}/form")
+    fun queryStudentDetail(
+        @PathVariable uuid: String
+    ): ResponseEntity<QueryStudentFormDetailWebResponse> =
+        queryStudentAuthenticationFormDetailUseCase.execute(UUID.fromString(uuid))
+            .let { ResponseEntity.ok(it.toResponse()) }
 
     @PostMapping("/submit/{uuid}")
     fun submitUserFormValue(
@@ -222,6 +230,13 @@ class AuthenticationWebAdapter(
             totalSize = totalSize,
             contentSize = contentSize,
             last = last
+        )
+
+    private fun StudentAuthenticationFormResponseData.toResponse() =
+        QueryStudentFormDetailWebResponse(
+            markingBoardId = markingBoardId,
+            title = title,
+            content = content
         )
 
     private fun isValidUUID(uuid: String): Boolean {

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/AuthenticationWebAdapter.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/AuthenticationWebAdapter.kt
@@ -33,9 +33,9 @@ class AuthenticationWebAdapter(
     private val queryStudentFormListUseCase: QueryStudentFormListUseCase,
     private val queryStudentAuthenticationFormDetailUseCase: QueryStudentAuthenticationFormDetailUseCase
 ) {
-    @GetMapping("/form/{uuid}")
-    fun queryAuthenticationForm(@PathVariable uuid: String): ResponseEntity<QueryAuthenticationFormWebResponse> =
-        queryAuthenticationFormUseCase.execute(UUID.fromString(uuid))
+    @GetMapping("/form")
+    fun queryAuthenticationForm(): ResponseEntity<QueryAuthenticationFormWebResponse> =
+        queryAuthenticationFormUseCase.execute()
             .let { ResponseEntity.ok(it.toResponse()) }
 
     @GetMapping

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/dto/res/QueryStudentFormDetailWebResponse.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/authentication/dto/res/QueryStudentFormDetailWebResponse.kt
@@ -1,0 +1,9 @@
+package team.msg.sms.domain.authentication.dto.res
+
+import java.util.UUID
+
+data class QueryStudentFormDetailWebResponse(
+    val markingBoardId: UUID,
+    val title: String,
+    val content: List<StudentAuthenticationFormResponseData.Area>
+)


### PR DESCRIPTION
## 💡 배경 및 개요

학생이 제출한 폼을 선생님이 조회할 수 있도록 개발했습니다.

Resolves: #377

## 📃 작업내용

1. userFormValue에 setId가 계획한대로 저장 되지 않던 부분 수정 + 예전엔 maxCount가 2이상인 상황에서만 추가하던 상황을 제거
2.학생 디테일 조회 기능 개발 + 첫 조회시 type을 채점 중으로 변경
3.기존 선생님이 만든 폼 조회할때 받던 uuid를 받지 않고 active 컬럼이 true인 폼을 조회할수 있도록 코드변경

## 🙋‍♂️ 리뷰노트

ReadOnluUseCase를 사용하지 않은 이유는 채점 전에서 채점 중으로 변경하는 과정에서 update query가 발생하여 트랜잭션에 ReadOnly가 없는 UseCase로 작업하였습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
