### PR TITLE
placeHolder로 되어있던거 placeholder로 변경

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/dto/req/CreateAuthenticationFieldRequestData.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/dto/req/CreateAuthenticationFieldRequestData.kt
@@ -4,7 +4,7 @@ import team.msg.sms.domain.authentication.model.FieldType
 
 data class CreateAuthenticationFieldRequestData(
     val description: String?,
-    val placeHolder: String?,
+    val placeholder: String?,
     val fieldType: FieldType,
     val selectorSectionName: List<String>
 )

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/dto/res/AuthenticationSectionFieldResponseData.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/dto/res/AuthenticationSectionFieldResponseData.kt
@@ -8,5 +8,5 @@ data class AuthenticationSectionFieldResponseData(
     val fieldType: FieldType,
     val scoreDescription: String?,
     val values: List<AuthenticationSelectorValueResponseData>?,
-    val example: String?
+    val placeholder: String?
 )

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/model/AuthenticationField.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/model/AuthenticationField.kt
@@ -5,7 +5,7 @@ import java.util.UUID
 data class AuthenticationField(
     val id: UUID,
     val description: String?,
-    val placeHolder: String?,
+    val placeholder: String?,
     val groupId: UUID,
     val fieldInputType: FieldType,
     val sort: Int

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/CreateAuthenticationFormUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/CreateAuthenticationFormUseCase.kt
@@ -142,7 +142,7 @@ class CreateAuthenticationFormUseCase(
             AuthenticationField(
                 id = UUID.randomUUID(),
                 description = fieldData.description,
-                placeHolder = fieldData.placeHolder,
+                placeHolder = fieldData.placeholder,
                 groupId = groupId,
                 fieldInputType = fieldData.fieldType,
                 sort = index

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/CreateAuthenticationFormUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/CreateAuthenticationFormUseCase.kt
@@ -142,7 +142,7 @@ class CreateAuthenticationFormUseCase(
             AuthenticationField(
                 id = UUID.randomUUID(),
                 description = fieldData.description,
-                placeHolder = fieldData.placeholder,
+                placeholder = fieldData.placeholder,
                 groupId = groupId,
                 fieldInputType = fieldData.fieldType,
                 sort = index

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryAuthenticationFormUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryAuthenticationFormUseCase.kt
@@ -103,7 +103,7 @@ class QueryAuthenticationFormUseCase(
             AuthenticationSectionFieldResponseData(
                 fieldId = field.id,
                 scoreDescription = field.description,
-                placeholder = field.placeHolder,
+                placeholder = field.placeholder,
                 fieldType = field.fieldInputType,
                 values = buildSelectorValues(field.fieldInputType, selectorSectionValues, field.id)
             )

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryAuthenticationFormUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryAuthenticationFormUseCase.kt
@@ -103,7 +103,7 @@ class QueryAuthenticationFormUseCase(
             AuthenticationSectionFieldResponseData(
                 fieldId = field.id,
                 scoreDescription = field.description,
-                example = field.placeHolder,
+                placeholder = field.placeHolder,
                 fieldType = field.fieldInputType,
                 values = buildSelectorValues(field.fieldInputType, selectorSectionValues, field.id)
             )

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/entity/AuthenticationFieldJpaEntity.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/entity/AuthenticationFieldJpaEntity.kt
@@ -17,7 +17,7 @@ class AuthenticationFieldJpaEntity(
     @Column(columnDefinition = "BINARY(16)", nullable = false)
     val groupId: UUID,
 
-    val placeHolder: String?,
+    val placeholder: String?,
 
     @Enumerated(EnumType.STRING)
     val fieldInputType: FieldType,

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/mapper/AuthenticationFieldMapper.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/authentication/mapper/AuthenticationFieldMapper.kt
@@ -7,7 +7,7 @@ fun AuthenticationFieldJpaEntity.toDomain() =
     AuthenticationField(
         id = id,
         description = description,
-        placeHolder = placeHolder,
+        placeholder = placeholder,
         groupId = groupId,
         fieldInputType = fieldInputType,
         sort = sort
@@ -17,7 +17,7 @@ fun AuthenticationField.toEntity() =
     AuthenticationFieldJpaEntity(
         id = id,
         description = description,
-        placeHolder = placeHolder,
+        placeholder = placeholder,
         groupId = groupId,
         fieldInputType = fieldInputType,
         sort = sort


### PR DESCRIPTION
## 💡 배경 및 개요

placeHolder의 표시가 placeholder이기에 변경 하였습니다

Resolves: #388 

## 📃 작업내용

폼을 생성할때 이제 placeHolder가 아닌 placeholder로 보내야함
폼을 조회할때 example이 아닌 placeholder로 받아야함

## 🙋‍♂️ 리뷰노트

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
