### PR TITLE
RedisRepository와 JpaRepository를 확실히 분리합니다

### DIFF
--- a/sms-infrastructure/src/main/resources/application.yml
+++ b/sms-infrastructure/src/main/resources/application.yml
@@ -18,6 +18,11 @@ spring:
     host: ${REDIS_HOST}
     port: ${REDIS_PORT}
 
+  data:
+    jpa:
+      repositories:
+        bootstrap-mode: deferred
+
   servlet:
     multipart:
       max-file-size: 50MB

--- a/sms-persistence/src/main/kotlin/team/msg/sms/global/config/JpaConfig.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/global/config/JpaConfig.kt
@@ -1,0 +1,31 @@
+package team.msg.sms.global.config
+
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.FilterType
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+
+
+@Configuration
+@EnableJpaRepositories(
+    basePackages = [
+        "team.msg.sms.persistence.authentication.repository",
+        "team.msg.sms.persistence.certificate.repository",
+        "team.msg.sms.persistence.file.repository",
+        "team.msg.sms.persistence.image.repository",
+        "team.msg.sms.persistence.languagecertificate.repository",
+        "team.msg.sms.persistence.major.repository",
+        "team.msg.sms.persistence.prize.repository",
+        "team.msg.sms.persistence.project.repository",
+        "team.msg.sms.persistence.region.repository",
+        "team.msg.sms.persistence.student.repository",
+        "team.msg.sms.persistence.teacher.repository",
+        "team.msg.sms.persistence.techstack.repository",
+        "team.msg.sms.persistence.user.repository",
+    ],
+    excludeFilters = [ComponentScan.Filter(
+        type = FilterType.ASPECTJ,
+        pattern = ["team.msg.sms.persistence.auth.repository.RefreshTokenRepository", "team.msg.sms.persistence.student.redisRepository.*"]
+    )]
+)
+class JpaConfig

--- a/sms-persistence/src/main/kotlin/team/msg/sms/global/config/RedisConfig.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/global/config/RedisConfig.kt
@@ -12,14 +12,13 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 import java.time.Duration
 
 @Configuration
-@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
+@EnableRedisRepositories(
+    enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP,
+    basePackages = ["team.msg.sms.persistence.auth.repository", "team.msg.sms.persistence.student.redisRepository"]
+)
 class RedisConfig(
-
-    @Value("\${spring.redis.host}")
-    private val redisHost: String,
-
-    @Value("\${spring.redis.port}")
-    private val redisPort: Int
+    @Value("\${spring.redis.host}") private val redisHost: String,
+    @Value("\${spring.redis.port}") private val redisPort: Int
 ) {
 
     @Bean

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/auth/repository/RefreshTokenRepository.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/auth/repository/RefreshTokenRepository.kt
@@ -1,6 +1,5 @@
 package team.msg.sms.persistence.auth.repository
 
-import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 import team.msg.sms.persistence.auth.entity.RefreshTokenEntity

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/file/FilePersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/file/FilePersistenceAdapter.kt
@@ -4,8 +4,8 @@ import org.springframework.stereotype.Component
 import team.msg.sms.domain.file.model.File
 import team.msg.sms.domain.file.model.FileType
 import team.msg.sms.domain.file.spi.FilePort
-import team.msg.sms.persistence.file.Repository.FileRepository
-import team.msg.sms.persistence.file.Repository.FileRepositoryCustom
+import team.msg.sms.persistence.file.repository.FileRepository
+import team.msg.sms.persistence.file.repository.FileRepositoryCustom
 import team.msg.sms.persistence.file.mapper.toDomain
 import team.msg.sms.persistence.file.mapper.toEntity
 import java.util.*

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/file/repository/FileRepository.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/file/repository/FileRepository.kt
@@ -1,4 +1,4 @@
-package team.msg.sms.persistence.file.Repository
+package team.msg.sms.persistence.file.repository
 
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/file/repository/FileRepositoryCustom.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/file/repository/FileRepositoryCustom.kt
@@ -1,6 +1,5 @@
-package team.msg.sms.persistence.file.Repository
+package team.msg.sms.persistence.file.repository
 
-import org.springframework.data.repository.query.Param
 import team.msg.sms.persistence.file.entity.FileJpaEntity
 import java.util.*
 

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/file/repository/FileRepositoryImpl.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/file/repository/FileRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package team.msg.sms.persistence.file.Repository
+package team.msg.sms.persistence.file.repository
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/student/StudentLinkPersistenceAdapter.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/student/StudentLinkPersistenceAdapter.kt
@@ -5,8 +5,7 @@ import team.msg.sms.domain.student.model.StudentLink
 import team.msg.sms.domain.student.spi.StudentLinkPort
 import team.msg.sms.persistence.student.mapper.toDomain
 import team.msg.sms.persistence.student.mapper.toEntity
-import team.msg.sms.persistence.student.repository.StudentJpaRepository
-import team.msg.sms.persistence.student.repository.StudentLinkRepository
+import team.msg.sms.persistence.student.redisRepository.StudentLinkRepository
 import java.util.*
 
 @Component

--- a/sms-persistence/src/main/kotlin/team/msg/sms/persistence/student/redisRepository/StudentLinkRepository.kt
+++ b/sms-persistence/src/main/kotlin/team/msg/sms/persistence/student/redisRepository/StudentLinkRepository.kt
@@ -1,4 +1,4 @@
-package team.msg.sms.persistence.student.repository
+package team.msg.sms.persistence.student.redisRepository
 
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
@@ -6,6 +6,6 @@ import team.msg.sms.persistence.student.entity.StudentLinkEntity
 
 @Repository
 interface StudentLinkRepository : CrudRepository<StudentLinkEntity, Long> {
-	fun existsByToken(token: String): Boolean
-	fun findByToken(token: String): StudentLinkEntity?
+    fun existsByToken(token: String): Boolean
+    fun findByToken(token: String): StudentLinkEntity?
 }


### PR DESCRIPTION
## 💡 배경 및 개요

서버를 실행할때 뜨던
![image](https://github.com/GSM-MSG/SMS-BackEnd/assets/81404026/6051b48e-b60b-4494-9b59-6fdc8a432ffd)
이런 로그를 없앴습니다.

Resolves: #392 

## 📃 작업내용

저 로그가 왜 뜨나 살펴본 결과 redis 테이블에서도 CrudRepository를 상속 받는 코드가 존재하면서 Spring data JPA repository 와 Spring data redis Repository가 모두 인식되어서 redis가 이게 내 리포지토리가 맞아? 그럼 명시해줘 라는 로그였습니다.

그래서 @EnableJpaRepositories 와 @EnableRedisRepositories로 빈을 주입할때 어떤 Repository를 주입할지 분리하였습니다.

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
