### PR TITLE
portfolioUrl 필수값으로 응답하도록 수정

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/dto/res/DetailStudentInfoTeacherResponseData.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/dto/res/DetailStudentInfoTeacherResponseData.kt
@@ -10,7 +10,7 @@ import team.msg.sms.domain.student.model.MilitaryService
 data class DetailStudentInfoTeacherResponseData(
     val name: String,
     val introduce: String,
-    val portfolioUrl: String?,
+    val portfolioUrl: String,
     val portfolioFileUrl: String?,
     val grade: Int,
     val classNum: Int,

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/dto/res/DetailStudentInfoTokenResponseData.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/dto/res/DetailStudentInfoTokenResponseData.kt
@@ -10,7 +10,7 @@ import team.msg.sms.domain.student.model.MilitaryService
 data class DetailStudentInfoTokenResponseData(
     val name: String,
     val introduce: String,
-    val portfolioUrl: String?,
+    val portfolioUrl: String,
     val portfolioFileUrl: String?,
     val grade: Int,
     val classNum: Int,

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/ModifyStudentInfoUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/ModifyStudentInfoUseCase.kt
@@ -71,7 +71,7 @@ class ModifyStudentInfoUseCase(
         val checkStudentMismatch = studentService.checkStudentDataMismatch(student, modifyStudentInfoDataModel)
         if (checkStudentMismatch) {
             val portfolioFileUrl =
-                if(student.portfolioUrl != modifyStudentInfoDataModel.portfolioUrl
+                if(student.portfolioUrl != modifyStudentInfoDataModel.portfolioUrl // true && true) //해당 데이터가 다르면서 수정 데이터는 있으면 null
                     && modifyStudentInfoData.portfolioUrl != null) null
                 else student.portfolioFileUrl
 

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/ModifyStudentInfoUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/ModifyStudentInfoUseCase.kt
@@ -299,6 +299,7 @@ class ModifyStudentInfoUseCase(
             }
 
             else -> when (departmentCode) {
+                "0" -> Department.SW_DEVELOPMENT
                 "1", "2" -> Department.SW_DEVELOPMENT
                 "3", "4" -> Department.SMART_IOT_DEVELOPMENT
                 else -> throw StuNumNotRightException

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/StudentInfoTeacherUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/StudentInfoTeacherUseCase.kt
@@ -13,6 +13,7 @@ import team.msg.sms.domain.project.service.ProjectService
 import team.msg.sms.domain.project.service.ProjectTechStackService
 import team.msg.sms.domain.region.service.RegionService
 import team.msg.sms.domain.student.dto.res.DetailStudentInfoTeacherResponseData
+import team.msg.sms.domain.student.model.Student
 import team.msg.sms.domain.student.model.StudentTechStack
 import team.msg.sms.domain.student.service.StudentService
 import team.msg.sms.domain.student.service.StudentTechStackService
@@ -48,7 +49,7 @@ class StudentInfoTeacherUseCase(
         return DetailStudentInfoTeacherResponseData(
             name = student.name,
             introduce = student.introduce,
-            portfolioUrl = student.portfolioUrl,
+            portfolioUrl = getStudentPortfolioUrl(student),
             portfolioFileUrl = student.portfolioFileUrl,
             grade = student.stuNum.substring(0, 1).toInt(),
             classNum = student.stuNum.substring(1, 2).toInt(),
@@ -90,5 +91,13 @@ class StudentInfoTeacherUseCase(
 
     private fun toStudentTechStacks(techStacks: List<TechStack>, studentTechStack: StudentTechStack): TechStack? =
         techStacks.find { it.id == studentTechStack.techStackId }
+
+    private fun getStudentPortfolioUrl(student: Student.StudentWithUserInfo): String {
+        return when {
+            !student.portfolioUrl.isNullOrBlank() -> student.portfolioUrl
+            !student.portfolioFileUrl.isNullOrBlank() -> student.portfolioFileUrl
+            else -> ""
+        }
+    }
 }
 

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/StudentInfoTokenUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/student/usecase/StudentInfoTokenUseCase.kt
@@ -52,7 +52,7 @@ class StudentInfoTokenUseCase(
         return DetailStudentInfoTokenResponseData(
             name = student.name,
             introduce = student.introduce,
-            portfolioUrl = student.portfolioUrl,
+            portfolioUrl = getStudentPortfolioUrl(student),
             portfolioFileUrl = student.portfolioFileUrl,
             grade = student.stuNum.substring(0, 1).toInt(),
             classNum = student.stuNum.substring(1, 2).toInt(),
@@ -94,5 +94,13 @@ class StudentInfoTokenUseCase(
 
     private fun toStudentTechStacks(techStacks: List<TechStack>, studentTechStack: StudentTechStack): TechStack? =
         techStacks.find { it.id == studentTechStack.techStackId }
+
+    private fun getStudentPortfolioUrl(student: Student.StudentWithUserInfo): String {
+        return when {
+            !student.portfolioUrl.isNullOrBlank() -> student.portfolioUrl
+            !student.portfolioFileUrl.isNullOrBlank() -> student.portfolioFileUrl
+            else -> ""
+        }
+    }
 }
 

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/user/dto/res/UserProfileDetailResponseData.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/user/dto/res/UserProfileDetailResponseData.kt
@@ -10,7 +10,7 @@ import team.msg.sms.domain.student.model.MilitaryService
 data class UserProfileDetailResponseData(
     val name: String,
     val introduce: String,
-    val portfolioUrl: String?,
+    val portfolioUrl: String,
     val portfolioFileUrl: String?,
     val grade: Int,
     val classNum: Int,

--- a/sms-core/src/main/kotlin/team/msg/sms/domain/user/usecase/QueryCurrentUserProfileDetailUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/user/usecase/QueryCurrentUserProfileDetailUseCase.kt
@@ -73,7 +73,7 @@ class QueryCurrentUserProfileDetailUseCase(
         UserProfileDetailResponseData(
             name = student.name,
             introduce = student.introduce,
-            portfolioUrl = student.portfolioUrl,
+            portfolioUrl = getStudentPortfolioUrl(student),
             portfolioFileUrl = student.portfolioFileUrl,
             grade = student.stuNum.substring(0, 1).toInt(),
             classNum = student.stuNum.substring(1, 2).toInt(),
@@ -113,4 +113,12 @@ class QueryCurrentUserProfileDetailUseCase(
 
     private fun toStudentTechStacks(techStacks: List<TechStack>, studentTechStack: StudentTechStack): TechStack? =
         techStacks.find { it.id == studentTechStack.techStackId }
+
+    private fun getStudentPortfolioUrl(student: Student.StudentWithUserInfo): String {
+        return when {
+            !student.portfolioUrl.isNullOrBlank() -> student.portfolioUrl
+            !student.portfolioFileUrl.isNullOrBlank() -> student.portfolioFileUrl
+            else -> ""
+        }
+    }
 }

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/student/dto/res/DetailStudentInfoTeacherWebResponse.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/student/dto/res/DetailStudentInfoTeacherWebResponse.kt
@@ -10,7 +10,7 @@ import team.msg.sms.domain.student.model.MilitaryService
 data class DetailStudentInfoTeacherWebResponse(
     val name: String,
     val introduce: String,
-    val portfolioUrl: String?,
+    val portfolioUrl: String,
     val portfolioFileUrl: String?,
     val grade: Int,
     val classNum: Int,

--- a/sms-presentation/src/main/kotlin/team/msg/sms/domain/student/dto/res/DetailStudentInfoTokenWebResponse.kt
+++ b/sms-presentation/src/main/kotlin/team/msg/sms/domain/student/dto/res/DetailStudentInfoTokenWebResponse.kt
@@ -10,7 +10,7 @@ import team.msg.sms.domain.student.model.MilitaryService
 data class DetailStudentInfoTokenWebResponse(
     val name: String,
     val introduce: String,
-    val portfolioUrl: String?,
+    val portfolioUrl: String,
     val portfolioFileUrl: String?,
     val grade: Int,
     val classNum: Int,


### PR DESCRIPTION
## 💡 배경 및 개요

현재 iOS, Android, Frontend 에서 portfolioUrl 필드가 Nullable처리에 대한 불명확한 이유로 인해, 현재로서는 필수값으로 바꾸면서 롤백을 진행하였습니다.

Resolves: #{이슈번호}
- portfolioUrl Nullable -> portfolioUrl required(true) 로 변경
- 기존 portfolioUrl 값을 -> portfolioUrl이나 portfolioFileUrl이 데이터 조회 해보고 없다면 빈 문자를 보내도록 수정

> PR에서 한 작업을 작성해주세요!

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
