### PR TITLE
🔁 인증제 폼을 찾을 수 없는 경우, 빈 배열을 반환

### DIFF
--- a/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryAuthenticationFormUseCase.kt
+++ b/sms-core/src/main/kotlin/team/msg/sms/domain/authentication/usecase/QueryAuthenticationFormUseCase.kt
@@ -11,7 +11,6 @@ import team.msg.sms.domain.authentication.service.*
 import team.msg.sms.domain.file.dto.res.FileResponseData
 import team.msg.sms.domain.file.service.FileService
 import java.util.*
-import kotlin.math.max
 
 @UseCase
 class QueryAuthenticationFormUseCase(
@@ -25,7 +24,15 @@ class QueryAuthenticationFormUseCase(
 ) {
     @Transactional(readOnly = true)
     fun execute(): QueryAuthenticationFormResponseData {
-        val authenticationFormId = authenticationFormService.getActiveAuthenticationFormId()
+        val authenticationFormId = runCatching {
+            authenticationFormService.getActiveAuthenticationFormId()
+        }.getOrNull()
+
+        authenticationFormId ?: return QueryAuthenticationFormResponseData(
+            files = emptyList(),
+            content = emptyList()
+        )
+
         val files = fetchFiles(authenticationFormId)
         val groups = fetchAuthenticationGroups(authenticationFormId)
         val authenticationSections = fetchAuthenticationSections(groups)


### PR DESCRIPTION
## 💡 배경 및 개요

클라이언트에서 인증제 페이지에 들어갔을때 404가 뜨는 것을 확인했고,
서버를 확인해보니 인증제 폼이 없는 경우 500이 반환되고 있는 문제를 발견해서,
없는 경우 빈 배열을 반환하도록 수정했습니다.

Resolves: #412 

## 🙋‍♂️ 리뷰노트

usecase의 반환값을 nullable로 변경하는 방법도 생각해봤지만 수정할 것이 많아질 것 같아서,
`runCatching` 함수를 이용해서 예외 처리하였습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
